### PR TITLE
feat: switch config to .env and add startup scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Simu-Emperor Server Configuration
+# Copy this file to .env and edit as needed.
+# All variables are prefixed with SIMU_.
+
+# --- Network ---
+SIMU_HOST=0.0.0.0
+SIMU_PORT=8000
+
+# --- Paths ---
+SIMU_DATA_DIR=data
+SIMU_DB_PATH=data/db/server.db
+SIMU_AGENT_TEMPLATES_DIR=data/agent_templates
+SIMU_AGENTS_DIR=data/agents
+SIMU_INITIAL_STATE_PATH=data/initial_state.json
+
+# --- Agent Process Management ---
+SIMU_AGENT_HEARTBEAT_TIMEOUT=90
+SIMU_AGENT_INVOCATION_TIMEOUT=600
+SIMU_AGENT_QUEUE_DEPTH=10
+
+# --- LLM (for agent generation only) ---
+SIMU_LLM_PROVIDER=anthropic
+SIMU_LLM_MODEL=claude-sonnet-4-20250514
+SIMU_LLM_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,9 @@ SIMU_AGENT_QUEUE_DEPTH=10
 SIMU_LLM_PROVIDER=anthropic
 SIMU_LLM_MODEL=claude-sonnet-4-20250514
 SIMU_LLM_API_KEY=
+# Custom base URL for OpenAI-compatible APIs (leave empty for default endpoints)
+# Examples:
+#   SIMU_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+#   SIMU_LLM_BASE_URL=https://api.deepseek.com/v1
+#   SIMU_LLM_BASE_URL=https://api.moonshot.cn/v1
+SIMU_LLM_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,8 @@ logs/
 
 # Environment
 .env
-.env.*
+.env.local
+.env.*.local
 claude_code_env.sh
 
 # uv

--- a/packages/sdk/simu_sdk/llm/anthropic.py
+++ b/packages/sdk/simu_sdk/llm/anthropic.py
@@ -18,7 +18,10 @@ class AnthropicProvider(LLMProvider):
 
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
-        self._client = AsyncAnthropic(api_key=config.api_key)
+        client_kwargs: dict[str, Any] = {"api_key": config.api_key}
+        if config.base_url:
+            client_kwargs["base_url"] = config.base_url
+        self._client = AsyncAnthropic(**client_kwargs)
 
     async def call(
         self,

--- a/packages/sdk/simu_sdk/llm/openai.py
+++ b/packages/sdk/simu_sdk/llm/openai.py
@@ -16,7 +16,10 @@ class OpenAIProvider(LLMProvider):
 
     def __init__(self, config: LLMConfig) -> None:
         self._config = config
-        self._client = AsyncOpenAI(api_key=config.api_key)
+        kwargs: dict[str, Any] = {"api_key": config.api_key}
+        if config.base_url:
+            kwargs["base_url"] = config.base_url
+        self._client = AsyncOpenAI(**kwargs)
 
     async def call(
         self,

--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "aiosqlite>=0.20",
     "sse-starlette>=2.0",
     "pydantic-settings>=2.0",
+    "python-dotenv>=1.0",
     "pyyaml>=6.0",
     "anthropic>=0.40",
     "openai>=1.50",

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -55,6 +55,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "provider": settings.llm_provider,
             "model": settings.llm_model,
             "api_key": settings.llm_api_key,
+            "base_url": settings.llm_base_url or None,
         },
     )
 

--- a/packages/server/simu_server/config.py
+++ b/packages/server/simu_server/config.py
@@ -35,6 +35,7 @@ class ServerConfig(BaseSettings):
     llm_provider: str = "anthropic"
     llm_model: str = "claude-sonnet-4-20250514"
     llm_api_key: str = ""
+    llm_base_url: str = ""  # Custom base URL for OpenAI-compatible APIs
 
 
 settings = ServerConfig()

--- a/packages/server/simu_server/config.py
+++ b/packages/server/simu_server/config.py
@@ -9,9 +9,12 @@ from pydantic_settings import BaseSettings
 
 
 class ServerConfig(BaseSettings):
-    """Server settings loaded from env vars / config file."""
+    """Server settings loaded from .env file and/or env vars.
 
-    model_config = {"env_prefix": "SIMU_"}
+    Precedence: env vars > .env file > defaults.
+    """
+
+    model_config = {"env_prefix": "SIMU_", "env_file": ".env", "env_file_encoding": "utf-8"}
 
     host: str = "0.0.0.0"
     port: int = 8000

--- a/packages/shared/simu_shared/models.py
+++ b/packages/shared/simu_shared/models.py
@@ -171,6 +171,7 @@ class LLMConfig(BaseModel):
     provider: str = "anthropic"  # "anthropic" | "openai" | "mock"
     model: str = "claude-sonnet-4-20250514"
     api_key: str = ""
+    base_url: str | None = None  # Custom base URL for OpenAI-compatible APIs
     temperature: float = 0.7
     max_tokens: int = 4096
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,53 +1,27 @@
 # Scripts
 
-此目录包含项目维护脚本。
+## start.sh
+
+Start the backend server (and optionally the frontend).
+
+```bash
+# Backend only
+./scripts/start.sh
+
+# Backend + frontend dev server
+./scripts/start.sh --with-web
+```
+
+On first run, copies `.env.example` to `.env` if no `.env` exists.
 
 ## clean_runtime_data.sh
 
-清理运行时生成的中间文件和日志。
+Clean runtime-generated data (databases, agent data, logs, caches).
 
-### 使用方法
-
-**干运行模式（推荐先运行）**：
 ```bash
+# Preview what would be deleted
 ./scripts/clean_runtime_data.sh --dry-run
-```
-只显示将要删除的文件，不实际删除。
 
-**实际删除**：
-```bash
+# Actually delete
 ./scripts/clean_runtime_data.sh
 ```
-
-### 清理的内容
-
-1. **游戏数据库**: `game.db`
-2. **Agent 运行时数据**: `data/agent/`（运行时副本，可从 `default_agents/` 重建）
-3. **记忆系统数据**: `data/memory/`（V3 记忆系统的 tape.jsonl、manifest.json）
-4. **会话数据**: `data/sessions/`
-5. **日志文件**: `data/logs/`、`logs/`
-6. **Python 缓存**: `__pycache__/`、`.pytest_cache/`、`.ruff_cache/`
-
-### 保留的内容
-
-- ✅ `default_agents/` - Agent 模板（未修改）
-- ✅ `skills/` - 技能模板
-- ✅ `saves/` - 存档文件
-- ✅ `config.yaml` - 配置文件
-- ✅ 所有源代码和测试代码
-
-### 何时使用
-
-- 运行测试后清理临时数据
-- 重新开始游戏时清除旧数据
-- 调试内存系统时重置状态
-- 减小仓库大小（删除已跟踪的运行时文件）
-
-### 警告
-
-⚠️ 此脚本会删除：
-- 游戏进度（无法恢复）
-- 记忆系统的历史记录
-- 所有日志文件
-
-请确保已保存重要数据后再运行！

--- a/scripts/clean_runtime_data.sh
+++ b/scripts/clean_runtime_data.sh
@@ -1,88 +1,59 @@
 #!/bin/bash
-# 清理运行时生成的中间文件和日志
-# 使用方法: ./scripts/clean_runtime_data.sh [--dry-run]
+# Clean runtime-generated data files and logs (V5 architecture).
+# Usage: ./scripts/clean_runtime_data.sh [--dry-run]
 
 set -e
 
-# 颜色输出
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# 干运行模式（只显示将要删除的内容，不实际删除）
 DRY_RUN=false
 if [ "$1" = "--dry-run" ]; then
     DRY_RUN=true
-    echo -e "${YELLOW}=== 干运行模式：只显示将要删除的文件，不实际删除 ===${NC}\n"
+    echo -e "${YELLOW}=== Dry run: showing files that would be deleted ===${NC}\n"
 fi
 
-# 删除文件的函数
-cleanup_file() {
+cleanup() {
     local file="$1"
-    local description="$2"
-
+    local desc="$2"
     if [ -e "$file" ]; then
         if [ "$DRY_RUN" = true ]; then
-            echo -e "${YELLOW}[干运行]${NC} 将删除: $file ($description)"
+            echo -e "${YELLOW}[dry-run]${NC} would delete: $file ($desc)"
         else
             rm -rf "$file"
-            echo -e "${GREEN}✓${NC} 已删除: $file ($description)"
+            echo -e "${GREEN}✓${NC} deleted: $file ($desc)"
         fi
-    else
-        echo -e "${YELLOW}-${NC} 不存在: $file ($description)"
     fi
 }
 
-echo -e "${RED}=== 清理运行时数据 ===${NC}\n"
+echo -e "${RED}=== Cleaning V5 runtime data ===${NC}\n"
 
-# 游戏数据库
-echo "1. 游戏数据库："
-cleanup_file "data/game.db" "游戏数据库文件"
+echo "1. Server database:"
+cleanup "data/db" "Server SQLite database"
 
-# 运行时数据目录
-echo -e "\n2. Agent 运行时数据："
-cleanup_file "data/agent" "Agent 运行时目录（soul.md、data_scope.yaml 等运行副本）"
+echo -e "\n2. Agent runtime data:"
+cleanup "data/agents" "Agent config & tape data"
 
-echo -e "\n3. 记忆系统数据："
-cleanup_file "data/memory" "V3 记忆系统目录（tape.jsonl、manifest.json）"
+echo -e "\n3. Group store:"
+cleanup "data/group_chats.json" "Group chat persistence"
 
-echo -e "\n4. 会话数据："
-cleanup_file "data/sessions" "会话数据目录"
+echo -e "\n4. Logs:"
+cleanup "data/logs" "Data directory logs"
+cleanup "logs" "Root directory logs"
 
-echo -e "\n5. 日志文件："
-cleanup_file "data/logs" "数据目录下的日志"
-cleanup_file "logs" "根目录下的日志"
+echo -e "\n5. Python caches:"
+cleanup "__pycache__" "Python bytecode cache"
+cleanup ".pytest_cache" "Pytest cache"
+cleanup ".ruff_cache" "Ruff cache"
 
-# Python 缓存
-echo -e "\n6. Python 缓存："
-cleanup_file "__pycache__" "Python 字节码缓存"
-cleanup_file ".pytest_cache" "Pytest 缓存"
-cleanup_file ".ruff_cache" "Ruff 缓存"
+echo -e "\n${GREEN}=== Clean complete ===${NC}"
 
-# 清理完成后的信息
-echo -e "\n${GREEN}=== 清理完成 ===${NC}"
-
-echo -e "\n${YELLOW}=== 保留的文件和目录 ===${NC}"
-echo "✅ default_agents/ - Agent 模板（未修改）"
-echo "✅ skills/ - 技能模板"
-echo "✅ saves/ - 存档文件"
-echo "✅ config.yaml - 配置文件"
-echo "✅ config.example.yaml - 配置示例"
-echo "✅ event_templates.json - 事件模板"
-echo "✅ initial_provinces.json - 初始省份数据"
-echo "✅ role_map.md - 角色映射"
-echo "✅ RULE.md - 规则文档"
-echo "✅ CLAUDE.md - Claude Code 指导文档"
-echo "✅ src/ - 源代码"
-echo "✅ tests/ - 测试代码"
-echo "✅ scripts/ - 脚本文件"
-echo "✅ data/skills/ - 技能文件（只读）"
-
-if [ "$DRY_RUN" = true ]; then
-    echo -e "\n${YELLOW}提示：这是干运行模式。要实际删除文件，请运行：${NC}"
-    echo "  ./scripts/clean_runtime_data.sh"
-else
-    echo -e "\n${GREEN}提示：如需查看将要删除的文件（不实际删除），请运行：${NC}"
-    echo "  ./scripts/clean_runtime_data.sh --dry-run"
-fi
+echo -e "\n${YELLOW}=== Preserved ===${NC}"
+echo "  data/agent_templates/  - Agent templates"
+echo "  data/initial_state.json - Initial game state"
+echo "  .env                   - Configuration"
+echo "  packages/              - Source code"
+echo "  tests/                 - Tests"
+echo "  web/                   - Frontend"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Start the simu-emperor backend server and (optionally) the frontend dev server.
+#
+# Usage:
+#   ./scripts/start.sh              # backend only
+#   ./scripts/start.sh --with-web   # backend + frontend
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+    if [ -f .env.example ]; then
+        echo "No .env found — copying from .env.example"
+        cp .env.example .env
+    else
+        echo "Warning: no .env file found. Using defaults."
+    fi
+fi
+
+# Ensure data directories exist
+mkdir -p data/db data/agents data/agent_templates
+
+# Sync dependencies
+echo "Syncing dependencies..."
+uv sync --quiet
+
+# Start backend
+echo "Starting backend server..."
+if [ "$1" = "--with-web" ]; then
+    # Start backend in background, frontend in foreground
+    uv run simu-emperor &
+    BACKEND_PID=$!
+    echo "Backend PID: $BACKEND_PID"
+
+    # Start frontend
+    echo "Starting frontend dev server..."
+    cd web
+    npm install --silent
+    npm run dev
+
+    # Clean up backend when frontend exits
+    kill $BACKEND_PID 2>/dev/null
+else
+    uv run simu-emperor
+fi


### PR DESCRIPTION
## Summary
- ServerConfig 改用 `.env` 文件管理配置（pydantic-settings + python-dotenv），保留环境变量覆盖能力
- 新增 `.env.example` 模板，包含所有可配置项及说明
- 新增 `scripts/start.sh` 一键启动脚本（支持 `--with-web` 同时启动前端）
- 更新 `scripts/clean_runtime_data.sh` 适配 V5 目录结构
- 修正 `.gitignore`：跟踪 `.env.example`，忽略 `.env`

## Test plan
- [ ] `cp .env.example .env` 后 `uv run simu-emperor` 正常启动
- [ ] 环境变量覆盖 `.env` 中的值（如 `SIMU_PORT=9000`）
- [ ] `./scripts/start.sh` 首次运行自动复制 `.env.example`
- [ ] `./scripts/start.sh --with-web` 同时启动后端和前端
- [ ] `uv run pytest -q` 通过

Generated with [Claude Code](https://claude.com/claude-code)