### PR TITLE
fix: sessions not visible, logs hidden, agents not responding

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -178,6 +178,14 @@ class BaseAgent:
         )
         await self.tape.append(response_event)
 
+        # Send response back to server so it appears in MessageStore / frontend
+        if result.content:
+            await self.server.post_message(
+                recipients=["player"],
+                message=result.content,
+                session_id=event.session_id,
+            )
+
         # Report invocation completion
         if event.invocation_id:
             await self.server.complete_invocation(event.invocation_id)

--- a/packages/sdk/simu_sdk/config.py
+++ b/packages/sdk/simu_sdk/config.py
@@ -30,9 +30,20 @@ class AgentConfig(BaseModel):
     @classmethod
     def from_env(cls) -> AgentConfig:
         """Build config from environment variables set by Server."""
+        llm_kwargs: dict[str, str] = {}
+        if os.environ.get("SIMU_LLM_PROVIDER"):
+            llm_kwargs["provider"] = os.environ["SIMU_LLM_PROVIDER"]
+        if os.environ.get("SIMU_LLM_MODEL"):
+            llm_kwargs["model"] = os.environ["SIMU_LLM_MODEL"]
+        if os.environ.get("SIMU_LLM_API_KEY"):
+            llm_kwargs["api_key"] = os.environ["SIMU_LLM_API_KEY"]
+        if os.environ.get("SIMU_LLM_BASE_URL"):
+            llm_kwargs["base_url"] = os.environ["SIMU_LLM_BASE_URL"]
+
         return cls(
             agent_id=os.environ["SIMU_AGENT_ID"],
             server_url=os.environ.get("SIMU_SERVER_URL", "http://localhost:8000"),
             agent_token=os.environ.get("SIMU_AGENT_TOKEN", ""),
             config_path=Path(os.environ.get("SIMU_CONFIG_PATH", ".")),
+            llm=LLMConfig(**llm_kwargs) if llm_kwargs else LLMConfig(),
         )

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -129,6 +129,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     client.set_dependencies(**deps)
     callback.set_dependencies(**deps)
 
+    # Spawn agent processes for all registered agents
+    for agent in await agent_registry.list_all():
+        if agent.config_path:
+            try:
+                pid = await process_manager.spawn(agent)
+                logger.info("Spawned agent %s (PID %d)", agent.agent_id, pid)
+            except Exception:
+                logger.warning("Failed to spawn agent %s", agent.agent_id, exc_info=True)
+
     logger.info("Server started on %s:%d", settings.host, settings.port)
     yield
 

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -43,7 +43,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     queue_controller = QueueController(max_depth=settings.agent_queue_depth)
 
     server_url = f"http://localhost:{settings.port}"
-    process_manager = ProcessManager(server_url)
+    process_manager = ProcessManager(
+        server_url,
+        llm_config={
+            "provider": settings.llm_provider,
+            "model": settings.llm_model,
+            "api_key": settings.llm_api_key,
+            "base_url": settings.llm_base_url or "",
+        },
+    )
 
     # Agent registry
     agent_registry = AgentRegistry(db)

--- a/packages/server/simu_server/services/process_manager.py
+++ b/packages/server/simu_server/services/process_manager.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 import uuid
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,7 @@ class ProcessManager:
         }
 
         proc = await asyncio.create_subprocess_exec(
-            "python", "-m", "simu_sdk.agent",
+            sys.executable, "-m", "simu_sdk.agent",
             env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/packages/server/simu_server/services/process_manager.py
+++ b/packages/server/simu_server/services/process_manager.py
@@ -25,10 +25,12 @@ _GRACEFUL_SHUTDOWN_TIMEOUT = 30  # seconds
 class ProcessManager:
     """Spawn and manage Agent child processes."""
 
-    def __init__(self, server_url: str) -> None:
+    def __init__(self, server_url: str, llm_config: dict[str, str] | None = None) -> None:
         self._server_url = server_url
+        self._llm_config = llm_config or {}
         self._processes: dict[str, asyncio.subprocess.Process] = {}
         self._tokens: dict[str, str] = {}  # agent_id → callback_token
+        self._log_tasks: dict[str, list[asyncio.Task]] = {}
 
     async def spawn(self, registration: AgentRegistration) -> int:
         """Start an Agent subprocess.  Returns the PID."""
@@ -42,6 +44,15 @@ class ProcessManager:
             "SIMU_AGENT_TOKEN": token,
             "SIMU_CONFIG_PATH": registration.config_path,
         }
+        # Pass LLM config so agents can call the LLM
+        if self._llm_config.get("provider"):
+            env["SIMU_LLM_PROVIDER"] = self._llm_config["provider"]
+        if self._llm_config.get("model"):
+            env["SIMU_LLM_MODEL"] = self._llm_config["model"]
+        if self._llm_config.get("api_key"):
+            env["SIMU_LLM_API_KEY"] = self._llm_config["api_key"]
+        if self._llm_config.get("base_url"):
+            env["SIMU_LLM_BASE_URL"] = self._llm_config["base_url"]
 
         proc = await asyncio.create_subprocess_exec(
             sys.executable, "-m", "simu_sdk.agent",
@@ -50,10 +61,35 @@ class ProcessManager:
             stderr=asyncio.subprocess.PIPE,
         )
         self._processes[registration.agent_id] = proc
+
+        # Forward agent stdout/stderr to server logger
+        tasks = [
+            asyncio.create_task(self._pipe_log(registration.agent_id, proc.stdout, "stdout")),
+            asyncio.create_task(self._pipe_log(registration.agent_id, proc.stderr, "stderr")),
+        ]
+        self._log_tasks[registration.agent_id] = tasks
+
         logger.info(
             "Spawned agent %s as PID %d", registration.agent_id, proc.pid,
         )
         return proc.pid or 0
+
+    @staticmethod
+    async def _pipe_log(
+        agent_id: str,
+        stream: asyncio.StreamReader | None,
+        label: str,
+    ) -> None:
+        """Read lines from a subprocess stream and forward to the server logger."""
+        if stream is None:
+            return
+        while True:
+            line = await stream.readline()
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                logger.info("[agent:%s:%s] %s", agent_id, label, text)
 
     async def terminate(self, agent_id: str, graceful: bool = True) -> None:
         """Stop an Agent subprocess."""

--- a/packages/shared/simu_shared/models.py
+++ b/packages/shared/simu_shared/models.py
@@ -109,7 +109,7 @@ class RoutedMessage(BaseModel):
 class Session(BaseModel):
     """A collaboration session scoping Agent interactions."""
 
-    session_id: str = Field(default_factory=lambda: _make_id("ses"))
+    session_id: str = Field(default_factory=lambda: f"session:web:{uuid.uuid4().hex[:12]}")
     parent_id: str | None = None
     child_ids: list[str] = Field(default_factory=list)
     status: SessionStatus = SessionStatus.ACTIVE

--- a/scripts/clean_runtime_data.sh
+++ b/scripts/clean_runtime_data.sh
@@ -31,29 +31,35 @@ cleanup() {
 echo -e "${RED}=== Cleaning V5 runtime data ===${NC}\n"
 
 echo "1. Server database:"
-cleanup "data/db" "Server SQLite database"
+cleanup "data/db" "Server SQLite database (server.db + group_chats.json)"
 
 echo -e "\n2. Agent runtime data:"
-cleanup "data/agents" "Agent config & tape data"
+cleanup "data/agents" "Agent config & tape data (copied from default_agents on startup)"
 
-echo -e "\n3. Group store:"
-cleanup "data/group_chats.json" "Group chat persistence"
+echo -e "\n3. Memory dual-write:"
+cleanup "data/memory" "JSONL message logs & tape_meta index"
 
 echo -e "\n4. Logs:"
+cleanup "data/server.log" "Server log (from start.sh)"
 cleanup "data/logs" "Data directory logs"
 cleanup "logs" "Root directory logs"
 
 echo -e "\n5. Python caches:"
-cleanup "__pycache__" "Python bytecode cache"
+find . -type d -name "__pycache__" -not -path "./web/*" -not -path "./.venv/*" | while read d; do
+    cleanup "$d" "Python bytecode cache"
+done
 cleanup ".pytest_cache" "Pytest cache"
 cleanup ".ruff_cache" "Ruff cache"
 
 echo -e "\n${GREEN}=== Clean complete ===${NC}"
 
 echo -e "\n${YELLOW}=== Preserved ===${NC}"
-echo "  data/agent_templates/  - Agent templates"
-echo "  data/initial_state.json - Initial game state"
-echo "  .env                   - Configuration"
-echo "  packages/              - Source code"
-echo "  tests/                 - Tests"
-echo "  web/                   - Frontend"
+echo "  data/default_agents/     - Default agent definitions"
+echo "  data/agent_templates/    - Agent templates"
+echo "  data/initial_state.json  - Initial game state"
+echo "  data/event_templates.json - Event templates"
+echo "  data/skills/             - Skill definitions"
+echo "  .env                     - Configuration"
+echo "  packages/                - Source code"
+echo "  tests/                   - Tests"
+echo "  web/                     - Frontend"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -27,13 +27,20 @@ mkdir -p data/db data/agents data/agent_templates
 echo "Syncing dependencies..."
 uv sync --quiet
 
+# Ensure data/memory directory exists for dual-write
+mkdir -p data/memory
+
 # Start backend
 echo "Starting backend server..."
 if [ "$1" = "--with-web" ]; then
-    # Start backend in background, frontend in foreground
-    uv run simu-emperor &
+    # Start backend in background with logs piped to a file AND terminal
+    LOGFILE="data/server.log"
+    uv run simu-emperor 2>&1 | tee "$LOGFILE" &
     BACKEND_PID=$!
-    echo "Backend PID: $BACKEND_PID"
+    echo "Backend PID: $BACKEND_PID (logs: $LOGFILE)"
+
+    # Wait briefly for backend to start
+    sleep 2
 
     # Start frontend
     echo "Starting frontend dev server..."


### PR DESCRIPTION
## Summary
- **Session not in frontend**: Session IDs used `ses_` prefix but frontend filters for `session:web:*`. Fixed to generate `session:web:{uuid}` IDs.
- **Backend logs not visible**: Startup script hid backend output when running with `--with-web`. Now uses `tee` to pipe to both terminal and `data/server.log`.
- **Agents not responding**: Agent processes were never spawned at startup — `process_manager.spawn()` was never called. Added spawn loop in lifespan. Also fixed to use `sys.executable` instead of bare `python` for correct virtualenv.

## Test plan
- [ ] Create a session → verify it appears in the frontend session selector
- [ ] Run `./scripts/start.sh --with-web` → verify backend logs are visible in terminal
- [ ] Send a message to an agent → verify agent process starts and responds
- [ ] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)