### PR TITLE
fix: game state API response format for frontend

### DIFF
--- a/packages/server/simu_server/config.py
+++ b/packages/server/simu_server/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -26,7 +25,7 @@ class ServerConfig(BaseSettings):
     agent_templates_dir: Path = Path("data/agent_templates")
     agents_dir: Path = Path("data/agents")
     default_agents_dir: Path = Path("data/default_agents")
-    initial_state_path: Path = Path("data/initial_state.json")
+    initial_state_path: Path = Path("data/initial_state_v4.json")
 
     # Agent process management
     agent_heartbeat_timeout: int = 90  # seconds

--- a/packages/server/simu_server/engine/state.py
+++ b/packages/server/simu_server/engine/state.py
@@ -8,11 +8,10 @@ from __future__ import annotations
 
 import json
 import logging
-from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
-from simu_shared.models import NationData, ProvinceData
+from simu_shared.models import NationData
 from simu_server.stores.database import Database
 
 logger = logging.getLogger(__name__)
@@ -36,7 +35,14 @@ class GameState:
             logger.info("Game state loaded from DB (turn %d)", self.nation.turn)
         elif initial_state_path and initial_state_path.exists():
             data = json.loads(initial_state_path.read_text(encoding="utf-8"))
-            self.nation = NationData.model_validate(data)
+            # Support both flat and nested JSON formats.
+            # Nested: {"nation": {...}, "provinces": {...}}
+            # Flat: {"turn": 0, "provinces": {...}, ...}
+            if "nation" in data and "provinces" in data and "turn" not in data:
+                nation_dict = {**data["nation"], "provinces": data["provinces"]}
+            else:
+                nation_dict = data
+            self.nation = NationData.model_validate(nation_dict)
             await self.save()
             logger.info("Game state initialized from %s", initial_state_path)
         else:

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -5,6 +5,7 @@ Preserves all V4 Web API functionality per design constraint.
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -14,7 +15,7 @@ from simu_shared.constants import EventType
 from simu_shared.models import (
     AgentRegistration,
     AgentStatus,
-    Incident,
+    ProvinceData,
     RoutedMessage,
     TapeEvent,
 )
@@ -228,6 +229,49 @@ async def send_command(req: SendCommandRequest) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Game state helpers
+# ---------------------------------------------------------------------------
+
+
+def _province_to_dict(p: ProvinceData, base_tax_rate: Decimal) -> dict[str, Any]:
+    """Convert ProvinceData to frontend-friendly dict with float values."""
+    return {
+        "province_id": p.province_id,
+        "name": p.name,
+        "production_value": float(p.production_value),
+        "population": float(p.population),
+        "fixed_expenditure": float(p.fixed_expenditure),
+        "stockpile": float(p.stockpile),
+        "base_production_growth": float(p.base_production_growth),
+        "base_population_growth": float(p.base_population_growth),
+        "tax_modifier": float(p.tax_modifier),
+        "actual_tax_rate": float(base_tax_rate + p.tax_modifier),
+    }
+
+
+def _serialize_incidents(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Ensure incident effects have string-typed add/factor for frontend."""
+    result = []
+    for inc in raw:
+        effects = []
+        for eff in inc.get("effects", []):
+            effects.append({
+                "target_path": eff.get("target_path", ""),
+                "add": str(eff["add"]) if eff.get("add") is not None else None,
+                "factor": str(eff["factor"]) if eff.get("factor") is not None else None,
+            })
+        result.append({
+            "incident_id": inc.get("incident_id", ""),
+            "title": inc.get("title", ""),
+            "description": inc.get("description", ""),
+            "source": inc.get("source", "system"),
+            "remaining_ticks": inc.get("remaining_ticks", 0),
+            "effects": effects,
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Game state
 # ---------------------------------------------------------------------------
 
@@ -235,11 +279,22 @@ async def send_command(req: SendCommandRequest) -> dict[str, Any]:
 async def get_state() -> dict[str, Any]:
     engine = _get("engine")
     if engine is None:
-        return {"turn": 0, "state": {}, "incidents": []}
-    state = engine.query_state()
-    overview = engine.get_overview()
+        return {"turn": 0, "provinces": {}, "incidents": []}
+    nation = engine.state.nation
+    provinces = {
+        pid: _province_to_dict(p, nation.base_tax_rate)
+        for pid, p in nation.provinces.items()
+    }
     incidents = engine.list_incidents()
-    return {**overview, "state": state, "incidents": incidents}
+    return {
+        "turn": nation.turn,
+        "imperial_treasury": float(nation.imperial_treasury),
+        "base_tax_rate": float(nation.base_tax_rate),
+        "tribute_rate": float(nation.tribute_rate),
+        "fixed_expenditure": float(nation.fixed_expenditure),
+        "provinces": provinces,
+        "incidents": _serialize_incidents(incidents),
+    }
 
 
 @router.get("/overview")
@@ -356,7 +411,7 @@ async def list_incidents() -> list[dict[str, Any]]:
     engine = _get("engine")
     if engine is None:
         return []
-    return engine.list_incidents()
+    return _serialize_incidents(engine.list_incidents())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -1,0 +1,128 @@
+"""Tests for game state API response format and initial state loading."""
+
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from simu_shared.models import ProvinceData, Incident, Effect
+from simu_server.engine.state import GameState
+from simu_server.routes.client import _province_to_dict, _serialize_incidents
+
+
+# ---------------------------------------------------------------------------
+# _province_to_dict
+# ---------------------------------------------------------------------------
+
+class TestProvinceToDist:
+    def test_returns_float_values(self):
+        p = ProvinceData(
+            province_id="zhili",
+            name="直隶",
+            production_value=Decimal("100000"),
+            population=Decimal("2600000"),
+            fixed_expenditure=Decimal("50000"),
+            stockpile=Decimal("1200000"),
+        )
+        result = _province_to_dict(p, Decimal("0.10"))
+        assert isinstance(result["production_value"], float)
+        assert isinstance(result["population"], float)
+        assert isinstance(result["stockpile"], float)
+        assert result["production_value"] == 100000.0
+        assert result["population"] == 2600000.0
+
+    def test_actual_tax_rate(self):
+        p = ProvinceData(
+            province_id="zhili",
+            name="直隶",
+            tax_modifier=Decimal("0.05"),
+        )
+        result = _province_to_dict(p, Decimal("0.10"))
+        assert result["actual_tax_rate"] == pytest.approx(0.15)
+
+    def test_all_expected_keys(self):
+        p = ProvinceData(province_id="test", name="Test")
+        result = _province_to_dict(p, Decimal("0.10"))
+        expected_keys = {
+            "province_id", "name", "production_value", "population",
+            "fixed_expenditure", "stockpile", "base_production_growth",
+            "base_population_growth", "tax_modifier", "actual_tax_rate",
+        }
+        assert set(result.keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# _serialize_incidents
+# ---------------------------------------------------------------------------
+
+class TestSerializeIncidents:
+    def test_empty(self):
+        assert _serialize_incidents([]) == []
+
+    def test_decimal_effects_serialized_as_strings(self):
+        inc = Incident(
+            title="Flood",
+            description="A devastating flood",
+            effects=[Effect(target_path="provinces.zhili.production_value", add=Decimal("-5000"))],
+            remaining_ticks=3,
+        )
+        raw = [inc.model_dump()]
+        result = _serialize_incidents(raw)
+        assert len(result) == 1
+        assert result[0]["title"] == "Flood"
+        assert result[0]["effects"][0]["add"] == "-5000"
+        assert result[0]["effects"][0]["factor"] is None
+
+    def test_incident_fields(self):
+        inc = Incident(
+            title="Drought",
+            description="desc",
+            effects=[],
+            remaining_ticks=5,
+            source="agent:minister",
+        )
+        raw = [inc.model_dump()]
+        result = _serialize_incidents(raw)
+        assert result[0]["source"] == "agent:minister"
+        assert result[0]["remaining_ticks"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Initial state loading (nested JSON format)
+# ---------------------------------------------------------------------------
+
+class TestGameStateLoad:
+    @pytest.mark.asyncio
+    async def test_load_nested_format(self, tmp_path):
+        """Verify that the nested JSON format (nation + provinces at same level) loads."""
+        state_file = tmp_path / "initial_state.json"
+        state_file.write_text(json.dumps({
+            "nation": {
+                "turn": 0,
+                "base_tax_rate": "0.10",
+                "imperial_treasury": "100000",
+            },
+            "provinces": {
+                "zhili": {
+                    "province_id": "zhili",
+                    "name": "直隶",
+                    "production_value": "100000",
+                    "population": "2600000",
+                    "fixed_expenditure": "50000",
+                    "stockpile": "1200000",
+                },
+            },
+        }))
+
+        db = AsyncMock()
+        db.conn.execute = AsyncMock(return_value=AsyncMock(fetchone=AsyncMock(return_value=None)))
+        db.conn.commit = AsyncMock()
+
+        gs = GameState(db)
+        await gs.load(state_file)
+
+        assert gs.nation.imperial_treasury == Decimal("100000")
+        assert gs.nation.base_tax_rate == Decimal("0.10")
+        assert "zhili" in gs.nation.provinces
+        assert gs.nation.provinces["zhili"].production_value == Decimal("100000")


### PR DESCRIPTION
## Summary

- **`/api/state` response mismatch**: Frontend expects `provinces` at top level with float values; backend returned them nested under `state` key with Decimal strings. Restructured to match `GameStateResponse` type, including `actual_tax_rate` per province.
- **Initial state not loading**: Config defaulted to `data/initial_state.json` but file is `data/initial_state_v4.json`. Also fixed loader to handle the nested JSON format where `nation` and `provinces` are sibling keys.
- **`/api/incidents` serialization**: Decimal effect values could cause issues. Added explicit serialization matching frontend `IncidentEffect` type (add/factor as strings).

## Files Changed
| File | Change |
|------|--------|
| `routes/client.py` | Restructured `/api/state` and `/api/incidents` responses, added helper functions |
| `engine/state.py` | Fixed initial state JSON loading for nested format |
| `config.py` | Fixed default `initial_state_path` |
| `tests/test_game_state.py` | 7 new tests for response format and state loading |

## Test plan
- [x] All 12 tests pass (`uv run pytest tests/`)
- [x] `ruff check` clean
- [ ] Start server with `initial_state_v4.json`, verify `/api/state` returns provinces at top level with float values
- [ ] Verify frontend province selector and detail panel render correctly
- [ ] Verify incident list renders without "Cannot read properties of undefined" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)