### PR TITLE
feat: task session tools and session state management

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -30,7 +30,7 @@ from simu_sdk.react import ReActLoop, ReActResult
 from simu_sdk.tape.context import ContextManager
 from simu_sdk.tape.manager import TapeManager
 from simu_sdk.tools.registry import ToolRegistry
-from simu_sdk.tools.standard import StandardTools
+from simu_sdk.tools.standard import SessionStateManager, StandardTools
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +49,15 @@ class BaseAgent:
         # Communication
         self.server = ServerClient(config.server_url, config.agent_id, config.agent_token)
 
+        # Session state management
+        self.session_state = SessionStateManager()
+
         # LLM
         self.llm: LLMProvider = create_llm_provider(config.llm)
 
         # Tools
         self.tools = ToolRegistry()
-        self._standard_tools = StandardTools(self.server)
+        self._standard_tools = StandardTools(self.server, session_state=self.session_state)
         self.tools.register_provider(self._standard_tools)
         self.tools.register_provider(self)  # auto-register @tool methods on subclass
 
@@ -145,15 +148,76 @@ class BaseAgent:
             self._load_personality()
             return
 
+        # Handle task completion events — unblock parent session
+        if event.event_type in (EventType.TASK_FINISHED, EventType.TASK_FAILED):
+            await self._handle_task_completion(event)
+            return
+
+        # Handle reply events — unblock session waiting for reply
+        if event.event_type == EventType.AGENT_MESSAGE:
+            cleared = self._try_clear_pending_reply(event)
+            if cleared:
+                # Reply received — process queued messages if session unblocked
+                await self._process_queued_messages(event.session_id)
+                return
+
+        # Session-level blocking: if the session has pending tasks/replies, queue the event
+        if self.session_state.is_blocked(event.session_id):
+            logger.info(
+                "Session %s is blocked, queuing event %s",
+                event.session_id, event.event_id,
+            )
+            self.session_state.enqueue_message(event.session_id, event)
+            return
+
         await self.react(event)
+
+    async def _handle_task_completion(self, event: TapeEvent) -> None:
+        """Process a TASK_FINISHED or TASK_FAILED event."""
+        # Record in tape
+        await self.tape.append(event)
+
+        # The event arrives in the parent session — check if it unblocks
+        session_id = event.session_id
+        # The task_session_id is in the event payload or can be inferred
+        # For now, try to unblock by checking if all pending tasks are done
+        await self._process_queued_messages(session_id)
+
+    def _try_clear_pending_reply(self, event: TapeEvent) -> bool:
+        """Check if this event clears a pending reply. Returns True if it did."""
+        session_id = event.session_id
+        # Check if the origin_event_id matches a pending reply
+        origin = event.parent_event_id
+        if origin:
+            replies = self.session_state._pending_replies.get(session_id, set())
+            if origin in replies:
+                self.session_state.remove_pending_reply(session_id, origin)
+                return True
+        return False
+
+    async def _process_queued_messages(self, session_id: str) -> None:
+        """If session is no longer blocked, process queued messages."""
+        if self.session_state.is_blocked(session_id):
+            return
+
+        queued = self.session_state.drain_queue(session_id)
+        for queued_event in queued:
+            logger.info(
+                "Processing queued event %s for unblocked session %s",
+                queued_event.event_id, session_id,
+            )
+            await self.react(queued_event)
 
     async def react(self, event: TapeEvent) -> None:
         """Run the ReAct loop for an event."""
+        # Determine which session to use (may be redirected to active task session)
+        session_id = event.session_id
+
         # Record the incoming event in local tape
         await self.tape.append(event)
 
-        # Build context window
-        context = await self.context_manager.get_context(event.session_id)
+        # Build context window — uses the current session's tape
+        context = await self.context_manager.get_context(session_id)
 
         # Build system prompt
         system_prompt = self._build_system_prompt()
@@ -171,7 +235,7 @@ class BaseAgent:
             dst=event.dst,
             event_type=EventType.RESPONSE,
             payload={"content": result.content},
-            session_id=event.session_id,
+            session_id=session_id,
             parent_event_id=event.event_id,
             root_event_id=event.root_event_id or event.event_id,
             invocation_id=event.invocation_id,
@@ -179,11 +243,12 @@ class BaseAgent:
         await self.tape.append(response_event)
 
         # Send response back to server so it appears in MessageStore / frontend
-        if result.content:
+        # Only send for non-task sessions (task results go via finish_task)
+        if result.content and not session_id.startswith("task:"):
             await self.server.post_message(
                 recipients=["player"],
                 message=result.content,
-                session_id=event.session_id,
+                session_id=session_id,
             )
 
         # Report invocation completion

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -93,6 +93,53 @@ class ServerClient:
         return resp.json()
 
     # ------------------------------------------------------------------
+    # Task session management
+    # ------------------------------------------------------------------
+
+    async def create_task_session(
+        self,
+        parent_session_id: str,
+        goal: str,
+        description: str = "",
+        constraints: str = "",
+        timeout_seconds: int = 300,
+        depth: int = 1,
+    ) -> str:
+        """Create a task sub-session on the Server. Returns task_session_id."""
+        resp = await self._http.post(
+            "/api/callback/task-session/create",
+            json={
+                "parent_session_id": parent_session_id,
+                "goal": goal,
+                "description": description,
+                "constraints": constraints,
+                "timeout_seconds": timeout_seconds,
+                "depth": depth,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()["task_session_id"]
+
+    async def finish_task_session(
+        self,
+        task_session_id: str,
+        parent_session_id: str,
+        result: str,
+        status: str = "completed",
+    ) -> None:
+        """Mark a task session as completed/failed and notify parent."""
+        resp = await self._http.post(
+            "/api/callback/task-session/finish",
+            json={
+                "task_session_id": task_session_id,
+                "parent_session_id": parent_session_id,
+                "result": result,
+                "status": status,
+            },
+        )
+        resp.raise_for_status()
+
+    # ------------------------------------------------------------------
     # Invocation management
     # ------------------------------------------------------------------
 

--- a/packages/sdk/simu_sdk/tools/__init__.py
+++ b/packages/sdk/simu_sdk/tools/__init__.py
@@ -1,6 +1,6 @@
 """Tool registration and discovery system."""
 
 from simu_sdk.tools.registry import ToolRegistry, tool
-from simu_sdk.tools.standard import StandardTools
+from simu_sdk.tools.standard import SessionStateManager, StandardTools
 
-__all__ = ["StandardTools", "ToolRegistry", "tool"]
+__all__ = ["SessionStateManager", "StandardTools", "ToolRegistry", "tool"]

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -1,13 +1,17 @@
-"""Standard tools built into the SDK — only communication primitives.
+"""Standard tools built into the SDK — communication and task management.
 
-Per design, the SDK ships exactly two standard tools:
+Tools:
   1. send_message — send a message to other agents or the player
   2. query_state — query game state from the Server
+  3. create_task_session — create a task sub-session for focused work
+  4. finish_task_session — complete the current task session with a result
+  5. fail_task_session — mark the current task session as failed
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any
 
 from simu_sdk.tools.registry import tool
 
@@ -16,19 +20,35 @@ if TYPE_CHECKING:
 
     from simu_sdk.client import ServerClient
 
+logger = logging.getLogger(__name__)
+
+# Maximum nesting depth for task sessions
+MAX_TASK_DEPTH = 5
+
 
 class StandardTools:
-    """Minimal communication tool set.
+    """Communication and task management tool set.
 
-    Requires a ``ServerClient`` instance injected at construction time.
+    Requires a ``ServerClient`` instance and a reference to the agent's
+    session state manager for task session support.
     """
 
-    def __init__(self, server: ServerClient) -> None:
+    def __init__(
+        self,
+        server: ServerClient,
+        session_state: SessionStateManager | None = None,
+    ) -> None:
         self._server = server
+        self._session_state = session_state
 
     @tool(
         name="send_message",
-        description="Send a message to other agents or the player.",
+        description=(
+            "Send a message to other agents or the player. "
+            "Set await_reply=true when you need a response before continuing, "
+            "e.g. asking a question, issuing a command that requires confirmation, "
+            "or requesting information from another agent."
+        ),
         parameters={
             "recipients": {
                 "type": "array",
@@ -39,15 +59,26 @@ class StandardTools:
                 "type": "string",
                 "description": "Message content.",
             },
+            "await_reply": {
+                "type": "boolean",
+                "description": (
+                    "If true, the current session will wait for a reply before "
+                    "processing new messages. Use for questions, commands, or "
+                    "any scenario requiring a response."
+                ),
+                "default": False,
+            },
         },
         category="communication",
     )
     async def send_message(self, args: dict, event: TapeEvent) -> str:
-        await self._server.post_message(
+        event_id = await self._server.post_message(
             recipients=args["recipients"],
             message=args["message"],
             session_id=event.session_id,
         )
+        if args.get("await_reply") and self._session_state:
+            self._session_state.add_pending_reply(event.session_id, event_id)
         return "Message sent."
 
     @tool(
@@ -66,3 +97,225 @@ class StandardTools:
 
         result = await self._server.query_state(path=args.get("path", ""))
         return json.dumps(result, ensure_ascii=False, default=str)
+
+    @tool(
+        name="create_task_session",
+        description=(
+            "Create a task sub-session for focused work on a specific goal. "
+            "The task is assigned to yourself. After creation, your context "
+            "switches to the new task session. Use finish_task_session or "
+            "fail_task_session when done. Task sessions can be nested up to "
+            "5 levels deep."
+        ),
+        parameters={
+            "goal": {
+                "type": "string",
+                "description": "What the task should accomplish — the acceptance criteria.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Detailed description of the task.",
+            },
+            "constraints": {
+                "type": "string",
+                "description": "Constraints or requirements for task execution.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": "Maximum time in seconds for this task (default: 300).",
+                "default": 300,
+            },
+        },
+        category="session",
+    )
+    async def create_task_session(self, args: dict, event: TapeEvent) -> str:
+        if self._session_state is None:
+            return "Error: session state manager not available."
+
+        current_depth = self._session_state.get_depth(event.session_id)
+        if current_depth >= MAX_TASK_DEPTH:
+            return f"Error: maximum task nesting depth ({MAX_TASK_DEPTH}) reached."
+
+        task_session_id = await self._server.create_task_session(
+            parent_session_id=event.session_id,
+            goal=args["goal"],
+            description=args.get("description", ""),
+            constraints=args.get("constraints", ""),
+            timeout_seconds=args.get("timeout_seconds", 300),
+            depth=current_depth + 1,
+        )
+
+        # Register the new task session in state manager
+        self._session_state.register_task_session(
+            task_session_id=task_session_id,
+            parent_session_id=event.session_id,
+            depth=current_depth + 1,
+        )
+
+        # Mark parent as waiting for this task
+        self._session_state.add_pending_task(event.session_id, task_session_id)
+
+        # Switch context to the new task session
+        self._session_state.set_active_session(task_session_id)
+
+        logger.info(
+            "Created task session %s (parent=%s, depth=%d, goal=%s)",
+            task_session_id, event.session_id, current_depth + 1, args["goal"],
+        )
+        return f"Task session created: {task_session_id}. Context switched to task session."
+
+    @tool(
+        name="finish_task_session",
+        description=(
+            "Complete the current task session with a result. The result will "
+            "be sent to the parent session. Context switches back to the parent."
+        ),
+        parameters={
+            "result": {
+                "type": "string",
+                "description": "The outcome/result of the completed task.",
+            },
+        },
+        category="session",
+    )
+    async def finish_task_session(self, args: dict, event: TapeEvent) -> str:
+        if self._session_state is None:
+            return "Error: session state manager not available."
+
+        parent_id = self._session_state.get_parent(event.session_id)
+        if parent_id is None:
+            return "Error: not in a task session, or parent session unknown."
+
+        await self._server.finish_task_session(
+            task_session_id=event.session_id,
+            parent_session_id=parent_id,
+            result=args["result"],
+            status="completed",
+        )
+
+        # Remove from parent's pending tasks
+        self._session_state.remove_pending_task(parent_id, event.session_id)
+
+        # Switch context back to parent
+        self._session_state.set_active_session(parent_id)
+
+        logger.info("Finished task session %s, returning to %s", event.session_id, parent_id)
+        return f"Task completed. Context switched back to parent session {parent_id}."
+
+    @tool(
+        name="fail_task_session",
+        description=(
+            "Mark the current task session as failed. The reason will be "
+            "sent to the parent session. Context switches back to the parent."
+        ),
+        parameters={
+            "reason": {
+                "type": "string",
+                "description": "Why the task failed.",
+            },
+        },
+        category="session",
+    )
+    async def fail_task_session(self, args: dict, event: TapeEvent) -> str:
+        if self._session_state is None:
+            return "Error: session state manager not available."
+
+        parent_id = self._session_state.get_parent(event.session_id)
+        if parent_id is None:
+            return "Error: not in a task session, or parent session unknown."
+
+        await self._server.finish_task_session(
+            task_session_id=event.session_id,
+            parent_session_id=parent_id,
+            result=args["reason"],
+            status="failed",
+        )
+
+        # Remove from parent's pending tasks
+        self._session_state.remove_pending_task(parent_id, event.session_id)
+
+        # Switch context back to parent
+        self._session_state.set_active_session(parent_id)
+
+        logger.info("Failed task session %s, returning to %s", event.session_id, parent_id)
+        return f"Task failed. Context switched back to parent session {parent_id}."
+
+
+# ---------------------------------------------------------------------------
+# Session state manager — tracks pending tasks, replies, and context
+# ---------------------------------------------------------------------------
+
+class SessionStateManager:
+    """Tracks per-session state for task dispatch and message blocking.
+
+    Manages:
+      - pending_tasks: set of unfinished task sub-session IDs per session
+      - pending_replies: set of message IDs awaiting reply per session
+      - message_queue: events queued while session is blocked
+      - session hierarchy: parent/child relationships and nesting depth
+      - active session: which session the agent's ReAct loop should target
+    """
+
+    def __init__(self) -> None:
+        self._pending_tasks: dict[str, set[str]] = {}  # session_id → {task_session_ids}
+        self._pending_replies: dict[str, set[str]] = {}  # session_id → {message_ids}
+        self._message_queue: dict[str, list[Any]] = {}  # session_id → [events]
+        self._parents: dict[str, str] = {}  # task_session_id → parent_session_id
+        self._depths: dict[str, int] = {}  # session_id → depth (0 for root)
+        self._active_session: str | None = None
+
+    def is_blocked(self, session_id: str) -> bool:
+        """Check if a session is blocked (has pending tasks or replies)."""
+        has_tasks = bool(self._pending_tasks.get(session_id))
+        has_replies = bool(self._pending_replies.get(session_id))
+        return has_tasks or has_replies
+
+    # -- Pending tasks --
+
+    def add_pending_task(self, session_id: str, task_session_id: str) -> None:
+        self._pending_tasks.setdefault(session_id, set()).add(task_session_id)
+
+    def remove_pending_task(self, session_id: str, task_session_id: str) -> None:
+        tasks = self._pending_tasks.get(session_id)
+        if tasks:
+            tasks.discard(task_session_id)
+
+    # -- Pending replies --
+
+    def add_pending_reply(self, session_id: str, message_id: str) -> None:
+        self._pending_replies.setdefault(session_id, set()).add(message_id)
+
+    def remove_pending_reply(self, session_id: str, message_id: str) -> None:
+        replies = self._pending_replies.get(session_id)
+        if replies:
+            replies.discard(message_id)
+
+    # -- Message queue --
+
+    def enqueue_message(self, session_id: str, event: Any) -> None:
+        self._message_queue.setdefault(session_id, []).append(event)
+
+    def drain_queue(self, session_id: str) -> list[Any]:
+        return self._message_queue.pop(session_id, [])
+
+    # -- Session hierarchy --
+
+    def register_task_session(
+        self, task_session_id: str, parent_session_id: str, depth: int,
+    ) -> None:
+        self._parents[task_session_id] = parent_session_id
+        self._depths[task_session_id] = depth
+
+    def get_parent(self, session_id: str) -> str | None:
+        return self._parents.get(session_id)
+
+    def get_depth(self, session_id: str) -> int:
+        return self._depths.get(session_id, 0)
+
+    # -- Active session --
+
+    def set_active_session(self, session_id: str) -> None:
+        self._active_session = session_id
+
+    def get_active_session(self) -> str | None:
+        return self._active_session

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from simu_shared.constants import EventType
-from simu_shared.models import AgentStatus, InvocationStatus, RoutedMessage, TapeEvent
+from simu_shared.models import AgentStatus, InvocationStatus, RoutedMessage, SessionStatus, TapeEvent
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,22 @@ class InvocationCompleteRequest(BaseModel):
     invocation_id: str
     status: str = "succeeded"
     error: str | None = None
+
+
+class CreateTaskSessionRequest(BaseModel):
+    parent_session_id: str
+    goal: str
+    description: str = ""
+    constraints: str = ""
+    timeout_seconds: int = 300
+    depth: int = 1
+
+
+class FinishTaskSessionRequest(BaseModel):
+    task_session_id: str
+    parent_session_id: str
+    result: str
+    status: str = "completed"  # "completed" or "failed"
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +243,105 @@ async def complete_invocation(
     inv_mgr = _get("invocation_manager")
     status = InvocationStatus(req.status)
     await inv_mgr.complete(req.invocation_id, status, req.error)
+    return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Task session management
+# ---------------------------------------------------------------------------
+
+@router.post("/task-session/create")
+async def create_task_session(
+    req: CreateTaskSessionRequest,
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, Any]:
+    await _verify_agent(x_agent_id, x_callback_token)
+    sm = _get("session_manager")
+    msg_store = _get("message_store")
+
+    # Create child session with task: prefix
+    import uuid as _uuid
+    task_session_id = f"task:{_uuid.uuid4().hex[:12]}"
+    session = await sm.create(
+        created_by=f"agent:{x_agent_id}",
+        parent_id=req.parent_session_id,
+    )
+    # Override the auto-generated session_id with task: prefix
+    await sm._db.conn.execute(
+        "UPDATE sessions SET session_id = ? WHERE session_id = ?",
+        (task_session_id, session.session_id),
+    )
+    await sm._db.conn.commit()
+
+    # Store task metadata
+    await sm.update_metadata(task_session_id, {
+        "goal": req.goal,
+        "description": req.description,
+        "constraints": req.constraints,
+        "timeout_seconds": req.timeout_seconds,
+        "depth": req.depth,
+        "created_by_agent": x_agent_id,
+    })
+
+    # Write TASK_CREATED event as first message in the task session
+    task_event = RoutedMessage(
+        session_id=task_session_id,
+        src=f"agent:{x_agent_id}",
+        dst=[f"agent:{x_agent_id}"],
+        content=f"Task created: {req.goal}",
+        event_type=EventType.TASK_CREATED,
+    )
+    await msg_store.store(task_event)
+
+    logger.info(
+        "Agent %s created task session %s (parent=%s, goal=%s)",
+        x_agent_id, task_session_id, req.parent_session_id, req.goal,
+    )
+    return {"task_session_id": task_session_id}
+
+
+@router.post("/task-session/finish")
+async def finish_task_session(
+    req: FinishTaskSessionRequest,
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, str]:
+    await _verify_agent(x_agent_id, x_callback_token)
+    sm = _get("session_manager")
+    msg_store = _get("message_store")
+    ws_mgr = _get("ws_manager")
+
+    # Mark task session as completed/failed
+    new_status = SessionStatus.COMPLETED if req.status == "completed" else SessionStatus.FAILED
+    await sm.update_status(req.task_session_id, new_status)
+
+    # Write finish event to the PARENT session so the creator sees it
+    event_type = EventType.TASK_FINISHED if req.status == "completed" else EventType.TASK_FAILED
+    finish_msg = RoutedMessage(
+        session_id=req.parent_session_id,
+        src=f"agent:{x_agent_id}",
+        dst=[f"agent:{x_agent_id}"],
+        content=req.result,
+        event_type=event_type,
+    )
+    await msg_store.store(finish_msg)
+
+    # Push to frontend WebSocket
+    await ws_mgr.broadcast({
+        "kind": "task_finished",
+        "data": {
+            "task_session_id": req.task_session_id,
+            "parent_session_id": req.parent_session_id,
+            "status": req.status,
+            "result": req.result,
+        },
+    })
+
+    logger.info(
+        "Agent %s finished task session %s (status=%s)",
+        x_agent_id, req.task_session_id, req.status,
+    )
     return {"status": "ok"}
 
 

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -266,13 +266,8 @@ async def create_task_session(
     session = await sm.create(
         created_by=f"agent:{x_agent_id}",
         parent_id=req.parent_session_id,
+        session_id=task_session_id,
     )
-    # Override the auto-generated session_id with task: prefix
-    await sm._db.conn.execute(
-        "UPDATE sessions SET session_id = ? WHERE session_id = ?",
-        (task_session_id, session.session_id),
-    )
-    await sm._db.conn.commit()
 
     # Store task metadata
     await sm.update_metadata(task_session_id, {

--- a/packages/server/simu_server/services/session_manager.py
+++ b/packages/server/simu_server/services/session_manager.py
@@ -18,8 +18,15 @@ class SessionManager:
     def __init__(self, db: Database) -> None:
         self._db = db
 
-    async def create(self, created_by: str = "player", parent_id: str | None = None) -> Session:
+    async def create(
+        self,
+        created_by: str = "player",
+        parent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> Session:
         session = Session(created_by=created_by, parent_id=parent_id)
+        if session_id:
+            session.session_id = session_id
         await self._db.conn.execute(
             """
             INSERT INTO sessions (session_id, parent_id, status, created_by, agent_ids, metadata, created_at, updated_at)

--- a/packages/shared/simu_shared/models.py
+++ b/packages/shared/simu_shared/models.py
@@ -56,9 +56,11 @@ class InvocationStatus(StrEnum):
 
 class SessionStatus(StrEnum):
     ACTIVE = "active"
+    WAITING_TASK = "waiting_task"
     WAITING_REPLY = "waiting_reply"
     FINISHED = "finished"
     FAILED = "failed"
+    COMPLETED = "completed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Task session tools**: Agents can self-create structured task sub-sessions (`create_task_session`), complete them (`finish_task_session`), or fail them (`fail_task_session`)
- **Session state management**: Per-session blocking — when a session has pending tasks or awaiting replies, new messages are queued until the session unblocks
- **send_message await_reply**: New `await_reply` parameter blocks the session until a reply is received
- **Server callback API**: New endpoints for creating and finishing task sessions with structured metadata
- **Nesting**: Task sessions can nest up to 5 levels deep, each with isolated context

## Design (confirmed with @SolidYang)
- Agent receives message → decides to create task for itself → context switches to task session
- Task session has structured first event (goal + description + constraints)
- Task sessions can create nested sub-tasks
- `finish_task_session` notifies parent session with result → parent unblocks → processes queued messages
- Session-level blocking (not agent-level): pending tasks or `await_reply` messages block the session

## Files changed
- `packages/sdk/simu_sdk/tools/standard.py` — 3 new tools + send_message await_reply + SessionStateManager
- `packages/sdk/simu_sdk/agent.py` — Session blocking logic in on_event, task completion handling
- `packages/sdk/simu_sdk/client.py` — create_task_session / finish_task_session API calls
- `packages/server/simu_server/routes/callback.py` — 2 new endpoints
- `packages/shared/simu_shared/models.py` — WAITING_TASK, COMPLETED status

## Test plan
- [ ] `uv run pytest` passes (12 tests)
- [ ] Agent can create task session via tool call
- [ ] Task session nesting respects max depth of 5
- [ ] finish_task_session writes event to parent session and unblocks it
- [ ] send_message with await_reply=true blocks session until reply
- [ ] Queued messages drain when session unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)