### PR TITLE
fix: re-initialize game state when DB has empty provinces

### DIFF
--- a/packages/server/simu_server/engine/state.py
+++ b/packages/server/simu_server/engine/state.py
@@ -30,10 +30,23 @@ class GameState:
             "SELECT value FROM game_state WHERE key = 'nation'",
         )
         row = await cursor.fetchone()
+        need_file_init = False
+
         if row:
-            self.nation = NationData.model_validate_json(row[0])
-            logger.info("Game state loaded from DB (turn %d)", self.nation.turn)
-        elif initial_state_path and initial_state_path.exists():
+            loaded = NationData.model_validate_json(row[0])
+            if loaded.provinces:
+                self.nation = loaded
+                logger.info("Game state loaded from DB (turn %d)", self.nation.turn)
+                return
+            logger.warning(
+                "DB state has no provinces (turn %d) — re-initializing from file",
+                loaded.turn,
+            )
+            need_file_init = True
+        else:
+            need_file_init = True
+
+        if need_file_init and initial_state_path and initial_state_path.exists():
             data = json.loads(initial_state_path.read_text(encoding="utf-8"))
             # Support both flat and nested JSON formats.
             # Nested: {"nation": {...}, "provinces": {...}}


### PR DESCRIPTION
## Summary

Follow-up to PR #52. The game state still shows all zeros because:

- Previous runs (with the wrong `initial_state_path`) saved an empty `NationData` to the DB
- On restart, `state.py` loads from DB first (which has empty provinces), so the JSON file is never read
- Now: if DB state has no provinces, fall through to file-based initialization and overwrite the empty DB entry

Also rebased on latest develop-v5 to include PR #51 fixes.

## Test plan
- [x] All 12 tests pass
- [x] ruff clean
- [ ] Start server (with existing DB that has empty state) — should auto-reinitialize from `initial_state_v4.json`
- [ ] Verify `/api/state` returns provinces with real data
- [ ] Verify frontend shows province data and treasury

🤖 Generated with [Claude Code](https://claude.com/claude-code)