### PR TITLE
Fix: resolve config paths relative to project root, not CWD

### DIFF
--- a/packages/server/simu_server/config.py
+++ b/packages/server/simu_server/config.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+
+def _find_project_root() -> Path:
+    """Walk up from this file to find the project root (contains data/ dir)."""
+    current = Path(__file__).resolve().parent
+    for _ in range(10):
+        if (current / "data").is_dir():
+            return current
+        current = current.parent
+    # Fallback to CWD if project root not found
+    return Path.cwd()
 
 
 class ServerConfig(BaseSettings):
@@ -18,7 +30,7 @@ class ServerConfig(BaseSettings):
     host: str = "0.0.0.0"
     port: int = 8000
 
-    # Paths
+    # Paths (relative paths are resolved against the project root)
     data_dir: Path = Path("data")
     db_path: Path = Path("data/db/server.db")
     memory_dir: Path = Path("data/memory")
@@ -37,6 +49,20 @@ class ServerConfig(BaseSettings):
     llm_model: str = "claude-sonnet-4-20250514"
     llm_api_key: str = ""
     llm_base_url: str = ""  # Custom base URL for OpenAI-compatible APIs
+
+    @model_validator(mode="after")
+    def _resolve_relative_paths(self) -> "ServerConfig":
+        """Resolve relative paths against the project root, not CWD."""
+        root = _find_project_root()
+        path_fields = [
+            "data_dir", "db_path", "memory_dir", "agent_templates_dir",
+            "agents_dir", "default_agents_dir", "initial_state_path",
+        ]
+        for field in path_fields:
+            p = getattr(self, field)
+            if not p.is_absolute():
+                setattr(self, field, root / p)
+        return self
 
 
 settings = ServerConfig()


### PR DESCRIPTION
## Summary
- Config paths (`data_dir`, `db_path`, `initial_state_path`, etc.) were relative and resolved against the process's CWD
- If the server was started from any directory other than the project root, `initial_state_path.exists()` returned `False` and game state was never loaded — resulting in all-zeros display on the frontend
- Added `_find_project_root()` that walks up from `config.py` to find the `data/` directory, and a `model_validator` that resolves all relative path fields against it

## Root Cause
`settings.initial_state_path` was `Path("data/initial_state_v4.json")` (relative). In `app.py:110`:
```python
initial_state = settings.initial_state_path if settings.initial_state_path.exists() else None
```
When CWD ≠ project root, `.exists()` fails → `None` passed to `GameState.load()` → empty state.

## Test plan
- [x] All 14 existing tests pass
- [x] `ruff check` clean
- [ ] Manual: start server from a non-root directory, verify game state loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)