### PR TITLE
Fix RuntimeWarning when spawning agent subprocesses

### DIFF
--- a/packages/sdk/simu_sdk/__main__.py
+++ b/packages/sdk/simu_sdk/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running the agent via ``python -m simu_sdk``."""
+
+from simu_sdk.agent import run_agent
+
+run_agent()

--- a/packages/server/simu_server/services/process_manager.py
+++ b/packages/server/simu_server/services/process_manager.py
@@ -12,10 +12,8 @@ import os
 import signal
 import sys
 import uuid
-from pathlib import Path
-from typing import Any
 
-from simu_shared.models import AgentRegistration, AgentStatus
+from simu_shared.models import AgentRegistration
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +53,7 @@ class ProcessManager:
             env["SIMU_LLM_BASE_URL"] = self._llm_config["base_url"]
 
         proc = await asyncio.create_subprocess_exec(
-            sys.executable, "-m", "simu_sdk.agent",
+            sys.executable, "-m", "simu_sdk",
             env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
## Summary
- `python -m simu_sdk.agent` caused a `RuntimeWarning` because `simu_sdk/__init__.py` eagerly imports `BaseAgent` from `simu_sdk.agent`, which puts the module in `sys.modules` before `-m` tries to execute it
- Added `simu_sdk/__main__.py` as the proper entry point, changed spawn command to `python -m simu_sdk`
- Cleaned up unused imports in `process_manager.py`

## Test plan
- [x] 14 tests pass
- [x] `ruff check` clean
- [ ] Manual: start server, verify no RuntimeWarning in agent stderr logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)