### PR TITLE
fix: agent response broadcast + role_map query tool

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -262,7 +262,30 @@ class BaseAgent:
         if self.data_scope:
             scope_text = yaml.dump(self.data_scope, allow_unicode=True, default_flow_style=False)
             parts.append(f"\n## Data Access Scope\n\n```yaml\n{scope_text}```")
+
+        # Task dispatch instructions
+        parts.append(self._task_dispatch_instructions())
+
         return "\n\n".join(parts)
+
+    @staticmethod
+    def _task_dispatch_instructions() -> str:
+        return """## 任务派发与跨官员沟通
+
+当玩家的指令涉及其他官员时（例如"问问张廷玉…"、"让各省加税"），按以下流程处理：
+
+1. **查询角色表**：调用 `query_role_map` 获取官员姓名与 agent_id 的对应关系。
+2. **创建任务会话**：调用 `create_task_session`，明确 goal（例如"向张廷玉询问身体状况"）。
+3. **发送消息并等待回复**：在任务会话中调用 `send_message`，设置 `await_reply=true`，向目标 agent 发送询问。
+4. **结束任务**：收到回复后，调用 `finish_task_session`，将结果汇总。
+5. **回复玩家**：回到主会话后，用 `send_message` 向 player 汇报结果。
+
+如果需要同时联系多位官员，可以为每位官员分别创建任务会话。
+
+注意：
+- 必须先用 `query_role_map` 查到 agent_id，不要猜测。
+- 与其他官员沟通时始终使用 `await_reply=true`，确保等到回复后再继续。
+- 任务会话结束后才回复玩家，保证信息完整。"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -92,6 +92,12 @@ class ServerClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def query_role_map(self) -> dict[str, Any]:
+        """Query role_map data from the Server."""
+        resp = await self._http.get("/api/callback/role-map")
+        resp.raise_for_status()
+        return resp.json()
+
     # ------------------------------------------------------------------
     # Task session management
     # ------------------------------------------------------------------

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -3,9 +3,10 @@
 Tools:
   1. send_message — send a message to other agents or the player
   2. query_state — query game state from the Server
-  3. create_task_session — create a task sub-session for focused work
-  4. finish_task_session — complete the current task session with a result
-  5. fail_task_session — mark the current task session as failed
+  3. query_role_map — look up court officials' names and agent IDs
+  4. create_task_session — create a task sub-session for focused work
+  5. finish_task_session — complete the current task session with a result
+  6. fail_task_session — mark the current task session as failed
 """
 
 from __future__ import annotations
@@ -97,6 +98,23 @@ class StandardTools:
 
         result = await self._server.query_state(path=args.get("path", ""))
         return json.dumps(result, ensure_ascii=False, default=str)
+
+    @tool(
+        name="query_role_map",
+        description=(
+            "Query the role map to find agent IDs for court officials. "
+            "Returns a list of all officials with their title (官职), name (姓名), "
+            "agent_id, and duty (职责). Use this to resolve a person's name "
+            "to an agent_id before sending messages to them."
+        ),
+        parameters={},
+        category="communication",
+    )
+    async def query_role_map(self, args: dict, event: TapeEvent) -> str:
+        import json
+
+        result = await self._server.query_role_map()
+        return json.dumps(result, ensure_ascii=False)
 
     @tool(
         name="create_task_session",

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -184,8 +184,20 @@ async def post_message(
         if r != "player":
             await queue.enqueue(r, event)
 
-    # Push to frontend WebSocket
-    await ws_mgr.broadcast({"kind": "agent_message", "data": event.model_dump(mode="json")})
+    # Push to frontend WebSocket — use "chat" kind with ChatData format
+    # so the frontend's existing 'chat' handler can process it.
+    agent_reg = await _get("agent_registry").get(x_agent_id)
+    display_name = agent_reg.display_name if agent_reg else x_agent_id
+    await ws_mgr.broadcast({
+        "kind": "chat",
+        "data": {
+            "agent": x_agent_id,
+            "agentDisplayName": display_name,
+            "text": req.message,
+            "timestamp": event.timestamp.isoformat(),
+            "session_id": req.session_id,
+        },
+    })
 
     return {"event_id": event.event_id}
 
@@ -227,6 +239,49 @@ async def query_agents(
         {"agent_id": a.agent_id, "display_name": a.display_name, "status": a.status.value}
         for a in agents
     ]
+
+
+@router.get("/role-map")
+async def query_role_map(
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, Any]:
+    """Return role_map.md content parsed into structured data."""
+    await _verify_agent(x_agent_id, x_callback_token)
+
+    from simu_server.config import settings
+
+    role_map_path = settings.data_dir / "role_map.md"
+    if not role_map_path.exists():
+        return {"roles": []}
+
+    text = role_map_path.read_text(encoding="utf-8")
+    roles: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("## "):
+            if current:
+                roles.append(current)
+            # Parse "## 户部尚书 (minister_of_revenue)"
+            title_part = line[3:].strip()
+            agent_id = ""
+            title = title_part
+            if "(" in title_part and ")" in title_part:
+                idx = title_part.index("(")
+                title = title_part[:idx].strip()
+                agent_id = title_part[idx + 1 : title_part.index(")")].strip()
+            current = {"title": title, "agent_id": agent_id, "name": "", "duty": ""}
+        elif line.startswith("- 姓名：") and current:
+            current["name"] = line[len("- 姓名：") :].strip()
+        elif line.startswith("- 职责：") and current:
+            current["duty"] = line[len("- 职责：") :].strip()
+
+    if current:
+        roles.append(current)
+
+    return {"roles": roles}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **WebSocket broadcast fix**: Server was broadcasting agent messages with `kind: "agent_message"` but frontend only registers handlers for `kind: "chat"`. Changed `callback.py` to broadcast agent messages with `kind: "chat"` and `ChatData` format, enabling real-time UI updates when agents respond.
- **`query_role_map` tool**: New `/api/callback/role-map` endpoint parses `data/role_map.md` and returns structured role data (title, name, agent_id, duty). SDK `StandardTools` exposes this as `query_role_map` so agents can resolve character names (张廷玉) to agent IDs (minister_of_revenue).
- **Task dispatch prompt**: `BaseAgent._build_system_prompt()` now injects instructions for the `query_role_map → create_task_session → send_message(await_reply) → finish_task_session → reply` workflow.

## Bugs Fixed

1. **"问问张廷玉身体如何" 无响应**: Agent had no way to resolve character names to agent IDs, and no instructions on how to use task dispatch. Now has `query_role_map` tool and system prompt guidance.
2. **Agent responses not appearing via WebSocket**: `kind: "agent_message"` broadcast was silently dropped by frontend. Now uses `kind: "chat"` with proper `ChatData` format.

## Files Changed

| File | Change |
|------|--------|
| `packages/server/simu_server/routes/callback.py` | Changed agent message broadcast to `kind: "chat"` format; added `/api/callback/role-map` endpoint |
| `packages/sdk/simu_sdk/client.py` | Added `query_role_map()` method |
| `packages/sdk/simu_sdk/tools/standard.py` | Added `query_role_map` tool |
| `packages/sdk/simu_sdk/agent.py` | Added task dispatch instructions to system prompt |

## Test plan

- [ ] Start server, verify agent messages appear in frontend chat in real-time (not just on polling refresh)
- [ ] Send "问问张廷玉身体如何" to any agent, verify it creates task session and contacts minister_of_revenue
- [ ] Verify `GET /api/callback/role-map` returns parsed role_map data
- [ ] Switch sessions in frontend, send message, verify it displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)