### PR TITLE
Fix: robust project root detection + diagnostic logging for state init

### DIFF
--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -108,6 +108,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Game engine
     engine = GameEngine(db)
     initial_state = settings.initial_state_path if settings.initial_state_path.exists() else None
+    logger.info(
+        "Initial state path: %s (exists=%s)",
+        settings.initial_state_path,
+        settings.initial_state_path.exists(),
+    )
     await engine.initialize(initial_state)
 
     # Wire queue dispatcher

--- a/packages/server/simu_server/config.py
+++ b/packages/server/simu_server/config.py
@@ -2,38 +2,56 @@
 
 from __future__ import annotations
 
+import logging
+import os
+import sys
 from pathlib import Path
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
+logger = logging.getLogger(__name__)
+
 
 def _find_project_root() -> Path:
     """Find the project root (the directory containing ``data/``).
 
-    Tries multiple strategies so it works regardless of install mode
-    (editable vs site-packages) and working directory.
+    Checks ``SIMU_PROJECT_ROOT`` env var first, then walks up from multiple
+    starting points to find the directory containing ``data/initial_state_v4.json``.
     """
-    candidates: list[Path] = []
+    # Explicit override — always wins
+    env_root = os.environ.get("SIMU_PROJECT_ROOT")
+    if env_root:
+        p = Path(env_root).resolve()
+        logger.info("Using SIMU_PROJECT_ROOT=%s", p)
+        return p
 
-    # Strategy 1: walk up from this source file (works for editable installs)
-    candidates.append(Path(__file__).resolve().parent)
-
-    # Strategy 2: walk up from CWD (works when run from project tree)
-    candidates.append(Path.cwd().resolve())
-
-    # Strategy 3: walk up from sys.prefix / venv root → likely near project
-    import sys
-    candidates.append(Path(sys.prefix).resolve())
+    marker = Path("data") / "initial_state_v4.json"
+    candidates: list[Path] = [
+        # Walk up from this source file (editable installs)
+        Path(__file__).resolve().parent,
+        # Walk up from CWD
+        Path.cwd().resolve(),
+        # Walk up from venv root (non-editable installs)
+        Path(sys.prefix).resolve(),
+        # Walk up from the Python executable itself
+        Path(sys.executable).resolve().parent,
+    ]
 
     for start in candidates:
         current = start
         for _ in range(10):
-            if (current / "data" / "initial_state_v4.json").is_file():
+            if (current / marker).is_file():
+                logger.info("Project root found: %s (from %s)", current, start)
                 return current
             current = current.parent
 
-    # Last resort
+    logger.warning(
+        "Could not find project root (looked for %s from %s). "
+        "Set SIMU_PROJECT_ROOT env var to fix this.",
+        marker,
+        [str(c) for c in candidates],
+    )
     return Path.cwd()
 
 

--- a/packages/server/simu_server/engine/state.py
+++ b/packages/server/simu_server/engine/state.py
@@ -26,6 +26,10 @@ class GameState:
 
     async def load(self, initial_state_path: Path | None = None) -> None:
         """Load state from DB, or initialize from a JSON file if DB is empty."""
+        logger.info(
+            "GameState.load called with initial_state_path=%s",
+            initial_state_path,
+        )
         cursor = await self._db.conn.execute(
             "SELECT value FROM game_state WHERE key = 'nation'",
         )


### PR DESCRIPTION
## Summary
- Added `SIMU_PROJECT_ROOT` env var — set this to the project root to bypass all auto-detection
- Added 4th search strategy (walk from `sys.executable`) for `_find_project_root()`
- Added diagnostic logging at every step: project root detection, initial_state_path value/exists, GameState.load entry
- If auto-detection fails, logs a clear warning with all paths tried

## Why
@SolidYang still sees `Starting with empty game state` after previous fixes. The diagnostic logs will reveal exactly what path is being checked and why it's not found. The `SIMU_PROJECT_ROOT` env var provides an immediate workaround.

## Immediate workaround
```bash
export SIMU_PROJECT_ROOT=/path/to/simu-emperor
```

## Test plan
- [x] 14 tests pass
- [x] `ruff check` clean (pre-existing unused import only)
- [ ] Manual: start server, check logs for path diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)