### PR TITLE
fix: tape recording, task session dispatch, sub-session visibility

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -210,7 +210,6 @@ class BaseAgent:
 
     async def react(self, event: TapeEvent) -> None:
         """Run the ReAct loop for an event."""
-        # Determine which session to use (may be redirected to active task session)
         session_id = event.session_id
 
         # Record the incoming event in local tape
@@ -227,6 +226,8 @@ class BaseAgent:
             system_prompt=system_prompt,
             event=event,
             context=context,
+            tape=self.tape,
+            agent_id=self.agent_id,
         )
 
         # Record the agent response in local tape
@@ -242,6 +243,14 @@ class BaseAgent:
         )
         await self.tape.append(response_event)
 
+        # Handle session transitions triggered by tools
+        if result.ended_by_tool == "create_task_session":
+            await self._enter_task_session(event)
+            return
+
+        # For finish/fail task session, the server sends TASK_FINISHED/FAILED
+        # event to the parent session, which is handled by _handle_task_completion.
+
         # Send response back to server so it appears in MessageStore / frontend
         # Only send for non-task sessions (task results go via finish_task)
         if result.content and not session_id.startswith("task:"):
@@ -254,6 +263,29 @@ class BaseAgent:
         # Report invocation completion
         if event.invocation_id:
             await self.server.complete_invocation(event.invocation_id)
+
+    async def _enter_task_session(self, parent_event: TapeEvent) -> None:
+        """Dispatch a synthetic event into a newly created task session."""
+        task_session_id = self.session_state.get_active_session()
+        if not task_session_id:
+            logger.warning("_enter_task_session called but no active session")
+            return
+
+        goal = self.session_state.get_goal(task_session_id)
+        logger.info(
+            "Entering task session %s (goal=%s)", task_session_id, goal,
+        )
+
+        # Create a synthetic event to kick off the task session
+        task_event = TapeEvent(
+            src=f"agent:{self.agent_id}",
+            dst=[f"agent:{self.agent_id}"],
+            event_type=EventType.TASK_CREATED,
+            payload={"content": f"Task: {goal}", "goal": goal},
+            session_id=task_session_id,
+            parent_event_id=parent_event.event_id,
+        )
+        await self.react(task_event)
 
     def _build_system_prompt(self) -> str:
         parts = []
@@ -274,18 +306,21 @@ class BaseAgent:
 
 当玩家的指令涉及其他官员时（例如"问问张廷玉…"、"让各省加税"），按以下流程处理：
 
-1. **查询角色表**：调用 `query_role_map` 获取官员姓名与 agent_id 的对应关系。
+1. **查询角色表**：先调用 `query_role_map` 获取官员姓名与 agent_id 的对应关系。
 2. **创建任务会话**：调用 `create_task_session`，明确 goal（例如"向张廷玉询问身体状况"）。
-3. **发送消息并等待回复**：在任务会话中调用 `send_message`，设置 `await_reply=true`，向目标 agent 发送询问。
-4. **结束任务**：收到回复后，调用 `finish_task_session`，将结果汇总。
-5. **回复玩家**：回到主会话后，用 `send_message` 向 player 汇报结果。
+   创建后你会自动进入任务会话上下文。
+3. **在任务会话中执行**：在任务会话中调用 `send_message`，设置 `await_reply=true`，向目标 agent 发送询问。
+   发送后会话自动暂停等待回复。
+4. **收到回复后结束任务**：回复到达后你会被唤醒，调用 `finish_task_session` 并附上汇总结果。
+5. **回到主会话**：结束任务后自动回到主会话，你会收到任务完成的通知，此时向 player 汇报结果。
 
-如果需要同时联系多位官员，可以为每位官员分别创建任务会话。
+如果需要同时联系多位官员，可以在主会话中依次创建多个任务。
 
-注意：
+重要规则：
 - 必须先用 `query_role_map` 查到 agent_id，不要猜测。
-- 与其他官员沟通时始终使用 `await_reply=true`，确保等到回复后再继续。
-- 任务会话结束后才回复玩家，保证信息完整。"""
+- 与其他官员沟通时始终使用 `await_reply=true`。
+- `create_task_session`、`finish_task_session`、`fail_task_session` 调用后会话会自动切换，无需额外操作。
+- `send_message(await_reply=true)` 发送后当前会话自动暂停，等待回复后继续。"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/react.py
+++ b/packages/sdk/simu_sdk/react.py
@@ -2,7 +2,7 @@
 
 The loop repeats:
   1. Call LLM with system prompt + context + current observations
-  2. If LLM returns tool calls → execute them, collect results
+  2. If LLM returns tool calls → execute them, collect results, record to tape
   3. If LLM returns text only → treat as final response, break
 
 Iteration and tool-call limits prevent runaway loops.
@@ -12,13 +12,16 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from simu_shared.constants import EventType
 from simu_shared.models import TapeEvent
 from simu_sdk.llm.base import LLMProvider, LLMResponse, ToolCall
 from simu_sdk.tape.context import ContextWindow
 from simu_sdk.tools.registry import ToolRegistry, ToolResult
+
+if TYPE_CHECKING:
+    from simu_sdk.tape.manager import TapeManager
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,8 @@ class ReActLoop:
         system_prompt: str,
         event: TapeEvent,
         context: ContextWindow,
+        tape: TapeManager | None = None,
+        agent_id: str = "",
     ) -> ReActResult:
         """Run the loop and return the final result."""
         messages = self._build_initial_messages(event, context)
@@ -67,6 +72,12 @@ class ReActLoop:
                     tool_calls_count=total_tool_calls,
                 )
 
+            # Record assistant reasoning + tool calls to tape
+            if tape:
+                await self._record_tool_calls(
+                    tape, event, response, agent_id,
+                )
+
             # Execute tool calls
             tool_results: list[dict[str, str]] = []
             for tc in response.tool_calls:
@@ -83,6 +94,12 @@ class ReActLoop:
                     "tool_call_id": tc.id,
                     "output": result.output,
                 })
+
+                # Record tool result to tape
+                if tape:
+                    await self._record_tool_result(
+                        tape, event, tc, result, agent_id,
+                    )
 
                 if result.ends_loop:
                     return ReActResult(
@@ -106,6 +123,58 @@ class ReActLoop:
             iterations=iterations,
             tool_calls_count=total_tool_calls,
         )
+
+    # ------------------------------------------------------------------
+    # Tape recording helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _record_tool_calls(
+        tape: TapeManager,
+        event: TapeEvent,
+        response: LLMResponse,
+        agent_id: str,
+    ) -> None:
+        """Record the assistant's reasoning and tool calls to tape."""
+        calls_summary = [
+            {"name": tc.name, "arguments": tc.arguments}
+            for tc in response.tool_calls
+        ]
+        tape_event = TapeEvent(
+            src=f"agent:{agent_id}",
+            dst=[f"agent:{agent_id}"],
+            event_type=EventType.TOOL_CALL,
+            payload={
+                "reasoning": response.content or "",
+                "tool_calls": calls_summary,
+            },
+            session_id=event.session_id,
+            parent_event_id=event.event_id,
+        )
+        await tape.append(tape_event)
+
+    @staticmethod
+    async def _record_tool_result(
+        tape: TapeManager,
+        event: TapeEvent,
+        tc: ToolCall,
+        result: ToolResult,
+        agent_id: str,
+    ) -> None:
+        """Record a single tool result (observation) to tape."""
+        tape_event = TapeEvent(
+            src=f"agent:{agent_id}",
+            dst=[f"agent:{agent_id}"],
+            event_type=EventType.TOOL_RESULT,
+            payload={
+                "tool_name": tc.name,
+                "output": result.output,
+                "success": result.success,
+            },
+            session_id=event.session_id,
+            parent_event_id=event.event_id,
+        )
+        await tape.append(tape_event)
 
     # ------------------------------------------------------------------
     # Message construction

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from simu_sdk.tools.registry import tool
+from simu_sdk.tools.registry import ToolResult, tool
 
 if TYPE_CHECKING:
     from simu_shared.models import TapeEvent
@@ -72,7 +72,7 @@ class StandardTools:
         },
         category="communication",
     )
-    async def send_message(self, args: dict, event: TapeEvent) -> str:
+    async def send_message(self, args: dict, event: TapeEvent) -> str | ToolResult:
         event_id = await self._server.post_message(
             recipients=args["recipients"],
             message=args["message"],
@@ -80,6 +80,10 @@ class StandardTools:
         )
         if args.get("await_reply") and self._session_state:
             self._session_state.add_pending_reply(event.session_id, event_id)
+            return ToolResult(
+                output="Message sent. Waiting for reply — session paused.",
+                ends_loop=True,
+            )
         return "Message sent."
 
     @tool(
@@ -146,7 +150,7 @@ class StandardTools:
         },
         category="session",
     )
-    async def create_task_session(self, args: dict, event: TapeEvent) -> str:
+    async def create_task_session(self, args: dict, event: TapeEvent) -> str | ToolResult:
         if self._session_state is None:
             return "Error: session state manager not available."
 
@@ -168,6 +172,7 @@ class StandardTools:
             task_session_id=task_session_id,
             parent_session_id=event.session_id,
             depth=current_depth + 1,
+            goal=args["goal"],
         )
 
         # Mark parent as waiting for this task
@@ -180,7 +185,10 @@ class StandardTools:
             "Created task session %s (parent=%s, depth=%d, goal=%s)",
             task_session_id, event.session_id, current_depth + 1, args["goal"],
         )
-        return f"Task session created: {task_session_id}. Context switched to task session."
+        return ToolResult(
+            output=f"Task session created: {task_session_id}. Processing task now.",
+            ends_loop=True,
+        )
 
     @tool(
         name="finish_task_session",
@@ -196,7 +204,7 @@ class StandardTools:
         },
         category="session",
     )
-    async def finish_task_session(self, args: dict, event: TapeEvent) -> str:
+    async def finish_task_session(self, args: dict, event: TapeEvent) -> str | ToolResult:
         if self._session_state is None:
             return "Error: session state manager not available."
 
@@ -218,7 +226,10 @@ class StandardTools:
         self._session_state.set_active_session(parent_id)
 
         logger.info("Finished task session %s, returning to %s", event.session_id, parent_id)
-        return f"Task completed. Context switched back to parent session {parent_id}."
+        return ToolResult(
+            output=f"Task completed. Returning to parent session {parent_id}.",
+            ends_loop=True,
+        )
 
     @tool(
         name="fail_task_session",
@@ -234,7 +245,7 @@ class StandardTools:
         },
         category="session",
     )
-    async def fail_task_session(self, args: dict, event: TapeEvent) -> str:
+    async def fail_task_session(self, args: dict, event: TapeEvent) -> str | ToolResult:
         if self._session_state is None:
             return "Error: session state manager not available."
 
@@ -256,7 +267,10 @@ class StandardTools:
         self._session_state.set_active_session(parent_id)
 
         logger.info("Failed task session %s, returning to %s", event.session_id, parent_id)
-        return f"Task failed. Context switched back to parent session {parent_id}."
+        return ToolResult(
+            output=f"Task failed. Returning to parent session {parent_id}.",
+            ends_loop=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +294,7 @@ class SessionStateManager:
         self._message_queue: dict[str, list[Any]] = {}  # session_id → [events]
         self._parents: dict[str, str] = {}  # task_session_id → parent_session_id
         self._depths: dict[str, int] = {}  # session_id → depth (0 for root)
+        self._goals: dict[str, str] = {}  # task_session_id → goal description
         self._active_session: str | None = None
 
     def is_blocked(self, session_id: str) -> bool:
@@ -320,15 +335,21 @@ class SessionStateManager:
 
     def register_task_session(
         self, task_session_id: str, parent_session_id: str, depth: int,
+        goal: str = "",
     ) -> None:
         self._parents[task_session_id] = parent_session_id
         self._depths[task_session_id] = depth
+        if goal:
+            self._goals[task_session_id] = goal
 
     def get_parent(self, session_id: str) -> str | None:
         return self._parents.get(session_id)
 
     def get_depth(self, session_id: str) -> int:
         return self._depths.get(session_id, 0)
+
+    def get_goal(self, session_id: str) -> str:
+        return self._goals.get(session_id, "")
 
     # -- Active session --
 

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -324,6 +324,9 @@ async def create_task_session(
         session_id=task_session_id,
     )
 
+    # Add the creating agent to the task session's agent list
+    await sm.add_agent(task_session_id, x_agent_id)
+
     # Store task metadata
     await sm.update_metadata(task_session_id, {
         "goal": req.goal,

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -582,8 +582,9 @@ async def get_subsessions(
             "created_at": s.created_at.isoformat() if s.created_at else "",
             "updated_at": s.updated_at.isoformat() if s.updated_at else "",
             "event_count": 0,
-            "depth": 1,
+            "depth": s.metadata.get("depth", 1),
             "status": s.status.value if hasattr(s.status, "value") else str(s.status),
+            "goal": s.metadata.get("goal", ""),
         })
     return result
 


### PR DESCRIPTION
## Summary

- **Tape records tool calls & observations**: ReAct loop now writes `TOOL_CALL` and `TOOL_RESULT` events to each agent's local tape, capturing assistant reasoning and tool outputs for context rebuilding across session switches.
- **Task session context switch**: `create_task_session` ends the current ReAct loop and dispatches a synthetic event into the new task session, triggering a new loop there. `send_message(await_reply=true)` pauses the session. `finish/fail_task_session` ends the task loop; the server's `TASK_FINISHED` event unblocks the parent.
- **Sub-session visibility**: Task sessions now have `agent_ids` populated (via `add_agent()`), so `/api/tape/subsessions` filtering works. Also returns `goal` and actual `depth` from metadata.

## Addresses Task #19

1. ✅ Tape is per-agent per-session; assistant_message and tool observations now recorded
2. ✅ ReAct intermediate steps (TOOL_CALL, TOOL_RESULT) written to tape for context rebuilding
3. ✅ Task session actually executes: create → enter task → send_message → await reply → finish → return
4. ✅ Task sub-sessions visible in frontend via `/api/tape/subsessions`

## Files Changed

| File | Change |
|------|--------|
| `packages/sdk/simu_sdk/react.py` | Added tape parameter; records TOOL_CALL and TOOL_RESULT events |
| `packages/sdk/simu_sdk/agent.py` | Passes tape to ReAct; `_enter_task_session()` dispatches into task session |
| `packages/sdk/simu_sdk/tools/standard.py` | Tools return `ToolResult(ends_loop=True)` for session-switching tools; `SessionStateManager` stores goals |
| `packages/server/simu_server/routes/callback.py` | `add_agent()` on task session creation |
| `packages/server/simu_server/routes/client.py` | Subsessions endpoint returns `goal` and actual `depth` |

## Test plan

- [ ] Send "问问张廷玉身体如何" — verify agent creates task, enters it, sends message, waits, finishes, replies
- [ ] Check agent tape files for TOOL_CALL and TOOL_RESULT events
- [ ] Verify sub-sessions appear in frontend "切换Session" dropdown
- [ ] Verify session blocking: parent session queues events while task is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)