### PR TITLE
fix: tape debug mirror, per-agent JSONL, task session prompt

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import signal
 from pathlib import Path
 from typing import Any
@@ -70,8 +71,13 @@ class BaseAgent:
         )
 
         # Tape (local) — stored under the agent's own config directory
+        # Also mirrors to data/memory/ if SIMU_MEMORY_DIR is set
         tape_dir = Path(config.config_path) / "tape"
-        self.tape = TapeManager(tape_dir)
+        memory_dir_env = os.environ.get("SIMU_MEMORY_DIR")
+        memory_dir = Path(memory_dir_env) if memory_dir_env else None
+        self.tape = TapeManager(
+            tape_dir, agent_id=config.agent_id, memory_dir=memory_dir,
+        )
         self.context_manager = ContextManager(self.tape, config.context)
 
         # Personality files
@@ -218,8 +224,8 @@ class BaseAgent:
         # Build context window — uses the current session's tape
         context = await self.context_manager.get_context(session_id)
 
-        # Build system prompt
-        system_prompt = self._build_system_prompt()
+        # Build system prompt (context-aware for task sessions)
+        system_prompt = self._build_system_prompt(session_id)
 
         # Execute ReAct loop
         result = await self.react_loop.run(
@@ -287,7 +293,7 @@ class BaseAgent:
         )
         await self.react(task_event)
 
-    def _build_system_prompt(self) -> str:
+    def _build_system_prompt(self, session_id: str = "") -> str:
         parts = []
         if self.soul:
             parts.append(self.soul)
@@ -295,8 +301,12 @@ class BaseAgent:
             scope_text = yaml.dump(self.data_scope, allow_unicode=True, default_flow_style=False)
             parts.append(f"\n## Data Access Scope\n\n```yaml\n{scope_text}```")
 
-        # Task dispatch instructions
-        parts.append(self._task_dispatch_instructions())
+        # Context-aware instructions
+        if session_id.startswith("task:"):
+            goal = self.session_state.get_goal(session_id)
+            parts.append(self._task_execution_instructions(goal))
+        else:
+            parts.append(self._task_dispatch_instructions())
 
         return "\n\n".join(parts)
 
@@ -321,6 +331,30 @@ class BaseAgent:
 - 与其他官员沟通时始终使用 `await_reply=true`。
 - `create_task_session`、`finish_task_session`、`fail_task_session` 调用后会话会自动切换，无需额外操作。
 - `send_message(await_reply=true)` 发送后当前会话自动暂停，等待回复后继续。"""
+
+    @staticmethod
+    def _task_execution_instructions(goal: str) -> str:
+        return f"""## 当前处于任务会话中
+
+你现在正在执行一个任务，目标是：**{goal}**
+
+在任务会话中，你应该：
+1. 直接执行任务 — 查询所需信息、向目标 agent 发送消息等
+2. 完成后调用 `finish_task_session`，将结果汇报
+3. 如果无法完成，调用 `fail_task_session` 说明原因
+
+**禁止在任务会话中再次创建 task session**，除非你发现必须委派给其他 agent 才能完成任务。绝大多数情况下，你应该直接执行。
+
+### 示例流程
+
+假设任务是 "向户部尚书张廷玉询问其身体状况，获取回复后向主会话汇报"：
+
+1. 调用 `query_role_map` 查到张廷玉的 agent_id 是 `minister_of_revenue`
+2. 调用 `send_message(recipients=["minister_of_revenue"], message="张廷玉大人，皇上关心您的身体状况，请据实禀报。", await_reply=true)`
+3. 等待回复（会话自动暂停）
+4. 收到回复后，调用 `finish_task_session(result="张廷玉回复：...")`
+
+请立即开始执行任务。"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -334,6 +334,7 @@ class BaseAgent:
 
     @staticmethod
     def _task_execution_instructions(goal: str) -> str:
+        """Generate execution instructions for task sessions."""
         return f"""## 当前处于任务会话中
 
 你现在正在执行一个任务，目标是：**{goal}**

--- a/packages/sdk/simu_sdk/tape/manager.py
+++ b/packages/sdk/simu_sdk/tape/manager.py
@@ -173,7 +173,7 @@ class TapeManager:
             with open(mirror_dir / "tape.jsonl", "a", encoding="utf-8") as f:
                 f.write(line)
         except Exception:
-            logger.debug("Failed to write memory mirror", exc_info=True)
+            logger.warning("Failed to write memory mirror", exc_info=True)
 
     @staticmethod
     def _row_to_event(row: tuple) -> TapeEvent:

--- a/packages/sdk/simu_sdk/tape/manager.py
+++ b/packages/sdk/simu_sdk/tape/manager.py
@@ -42,18 +42,29 @@ CREATE INDEX IF NOT EXISTS idx_tape_session ON tape_events (session_id, timestam
 class TapeManager:
     """Append-only event log with JSONL + SQLite dual-write.
 
-    Directory layout::
+    Directory layout (agent-local)::
 
         {base_dir}/
         ├── sessions/{session_id}/tape.jsonl
         └── tape.db
+
+    Optional debug mirror (shared, for debugging)::
+
+        {memory_dir}/agents/{agent_id}/sessions/{session_id}/tape.jsonl
     """
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(
+        self,
+        base_dir: Path,
+        agent_id: str = "",
+        memory_dir: Path | None = None,
+    ) -> None:
         self._base_dir = base_dir
         self._base_dir.mkdir(parents=True, exist_ok=True)
         self._db_path = base_dir / "tape.db"
         self._db: aiosqlite.Connection | None = None
+        self._agent_id = agent_id
+        self._memory_dir = memory_dir
 
     async def initialize(self) -> None:
         """Open the SQLite database and ensure schema exists."""
@@ -69,9 +80,10 @@ class TapeManager:
             self._db = None
 
     async def append(self, event: TapeEvent) -> None:
-        """Append an event to both JSONL and SQLite."""
+        """Append an event to both JSONL and SQLite, plus debug mirror."""
         await self._append_jsonl(event)
         await self._append_sqlite(event)
+        self._append_memory_mirror(event)
 
     async def query(
         self,
@@ -146,6 +158,22 @@ class TapeManager:
             ),
         )
         await self._db.commit()
+
+    def _append_memory_mirror(self, event: TapeEvent) -> None:
+        """Write event to shared data/memory/ for debugging (synchronous)."""
+        if not self._memory_dir or not self._agent_id:
+            return
+        try:
+            mirror_dir = (
+                self._memory_dir / "agents" / self._agent_id
+                / "sessions" / event.session_id
+            )
+            mirror_dir.mkdir(parents=True, exist_ok=True)
+            line = event.model_dump_json() + "\n"
+            with open(mirror_dir / "tape.jsonl", "a", encoding="utf-8") as f:
+                f.write(line)
+        except Exception:
+            logger.debug("Failed to write memory mirror", exc_info=True)
 
     @staticmethod
     def _row_to_event(row: tuple) -> TapeEvent:

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -51,6 +51,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             "api_key": settings.llm_api_key,
             "base_url": settings.llm_base_url or "",
         },
+        memory_dir=str(settings.memory_dir),
     )
 
     # Agent registry

--- a/packages/server/simu_server/services/process_manager.py
+++ b/packages/server/simu_server/services/process_manager.py
@@ -23,9 +23,15 @@ _GRACEFUL_SHUTDOWN_TIMEOUT = 30  # seconds
 class ProcessManager:
     """Spawn and manage Agent child processes."""
 
-    def __init__(self, server_url: str, llm_config: dict[str, str] | None = None) -> None:
+    def __init__(
+        self,
+        server_url: str,
+        llm_config: dict[str, str] | None = None,
+        memory_dir: str = "",
+    ) -> None:
         self._server_url = server_url
         self._llm_config = llm_config or {}
+        self._memory_dir = memory_dir
         self._processes: dict[str, asyncio.subprocess.Process] = {}
         self._tokens: dict[str, str] = {}  # agent_id → callback_token
         self._log_tasks: dict[str, list[asyncio.Task]] = {}
@@ -51,6 +57,8 @@ class ProcessManager:
             env["SIMU_LLM_API_KEY"] = self._llm_config["api_key"]
         if self._llm_config.get("base_url"):
             env["SIMU_LLM_BASE_URL"] = self._llm_config["base_url"]
+        if self._memory_dir:
+            env["SIMU_MEMORY_DIR"] = self._memory_dir
 
         proc = await asyncio.create_subprocess_exec(
             sys.executable, "-m", "simu_sdk",


### PR DESCRIPTION
## Summary

- **Tape debug mirror**: All agent tape events (including TOOL_CALL, TOOL_RESULT) are now mirrored to `data/memory/agents/{agent_id}/sessions/{session_id}/tape.jsonl`. Server passes `SIMU_MEMORY_DIR` env var to agents.
- **Per-agent per-session JSONL**: Debug output is organized by agent AND session for easy debugging.
- **Task session prompt**: System prompt is now context-aware. In task sessions, injects task-specific instructions with the goal, prohibits nested task creation, and includes a few-shot example of the query→send→finish flow.

## Addresses Task #20

1. ✅ TOOL_CALL/TOOL_RESULT events now visible in debug JSONL at `data/memory/agents/{agent_id}/sessions/{session_id}/tape.jsonl`
2. ✅ JSONL organized per-agent per-session
3. ✅ Agent no longer repeatedly creates tasks — task session prompt explicitly says "直接执行" with few-shot example

## Files Changed

| File | Change |
|------|--------|
| `packages/sdk/simu_sdk/tape/manager.py` | Added `memory_dir` param and `_append_memory_mirror()` |
| `packages/sdk/simu_sdk/agent.py` | Context-aware system prompt; `_task_execution_instructions()` for task sessions |
| `packages/server/simu_server/services/process_manager.py` | Passes `SIMU_MEMORY_DIR` env var to agents |
| `packages/server/simu_server/app.py` | Passes `memory_dir` to ProcessManager |

## Test plan

- [ ] Send "问问张廷玉身体如何", verify agent creates task then EXECUTES (not re-creates)
- [ ] Check `data/memory/agents/{agent_id}/sessions/{session_id}/tape.jsonl` for TOOL_CALL and TOOL_RESULT events
- [ ] Verify per-agent per-session directory structure in `data/memory/agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)