### PR TITLE
Add create_incident API with data_scope permission checks

### DIFF
--- a/data/default_agents/governor_jiangnan/data_scope.yaml
+++ b/data/default_agents/governor_jiangnan/data_scope.yaml
@@ -1,17 +1,11 @@
 display_name: 江南巡抚
 
-skills:
-  query_data:
-    provinces: [jiangnan]
-    fields:
-      - population.*
-      - agriculture.*
-      - commerce.*
-      - trade.*
-      - military.garrison_size
-      - military.morale
-      - granary_stock
-      - local_treasury
-
-  write_report:
-    inherits: query_data
+provinces: [jiangnan]
+fields:
+  - production_value
+  - population
+  - fixed_expenditure
+  - stockpile
+  - base_production_growth
+  - base_population_growth
+  - tax_modifier

--- a/data/default_agents/governor_zhili/data_scope.yaml
+++ b/data/default_agents/governor_zhili/data_scope.yaml
@@ -1,17 +1,11 @@
 display_name: 直隶巡抚
 
-skills:
-  query_data:
-    provinces: [zhili]
-    fields:
-      - population.*
-      - agriculture.*
-      - commerce.*
-      - trade.*
-      - military.garrison_size
-      - military.morale
-      - granary_stock
-      - local_treasury
-
-  write_report:
-    inherits: query_data
+provinces: [zhili]
+fields:
+  - production_value
+  - population
+  - fixed_expenditure
+  - stockpile
+  - base_production_growth
+  - base_population_growth
+  - tax_modifier

--- a/data/default_agents/minister_of_revenue/data_scope.yaml
+++ b/data/default_agents/minister_of_revenue/data_scope.yaml
@@ -1,15 +1,13 @@
 display_name: 户部尚书
 
-skills:
-  query_data:
-    national: [imperial_treasury, national_tax_modifier, tribute_rate]
-    provinces: all
-    fields:
-      - commerce.*
-      - trade.*
-      - taxation.*
-      - granary_stock
-      - local_treasury
-
-  write_report:
-    inherits: query_data
+provinces: all
+fields:
+  - production_value
+  - population
+  - stockpile
+  - tax_modifier
+nation_fields:
+  - imperial_treasury
+  - base_tax_rate
+  - tribute_rate
+  - fixed_expenditure

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -146,6 +146,34 @@ class ServerClient:
         resp.raise_for_status()
 
     # ------------------------------------------------------------------
+    # Incident creation
+    # ------------------------------------------------------------------
+
+    async def create_incident(
+        self,
+        title: str,
+        effects: list[dict[str, str]],
+        remaining_ticks: int,
+        description: str = "",
+        source: str = "",
+    ) -> dict[str, Any]:
+        """Create a new incident via the Server. Returns incident_id."""
+        resp = await self._http.post(
+            "/api/callback/incident",
+            json={
+                "title": title,
+                "description": description,
+                "effects": effects,
+                "remaining_ticks": remaining_ticks,
+                "source": source,
+            },
+        )
+        if resp.status_code != 200:
+            detail = resp.json().get("detail", resp.text)
+            return {"error": detail}
+        return resp.json()
+
+    # ------------------------------------------------------------------
     # Invocation management
     # ------------------------------------------------------------------
 

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -7,6 +7,7 @@ Tools:
   4. create_task_session — create a task sub-session for focused work
   5. finish_task_session — complete the current task session with a result
   6. fail_task_session — mark the current task session as failed
+  7. create_incident — create a time-limited event with economic effects
 """
 
 from __future__ import annotations
@@ -118,6 +119,74 @@ class StandardTools:
         import json
 
         result = await self._server.query_role_map()
+        return json.dumps(result, ensure_ascii=False)
+
+    @tool(
+        name="create_incident",
+        description=(
+            "Create a time-limited incident with economic effects on provinces or "
+            "the nation. Effects can be additive (one-time) or multiplicative "
+            "(per-tick). Your data_scope determines which provinces and fields you "
+            "can affect. Negative add values cannot reduce a field to zero or below. "
+            "Factor values must be >= 0."
+        ),
+        parameters={
+            "title": {
+                "type": "string",
+                "description": "Incident title, e.g. '直隶洪灾'.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Detailed description of the incident.",
+            },
+            "effects": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "target_path": {
+                            "type": "string",
+                            "description": (
+                                "Dot-notation path: 'provinces.{id}.{field}' for province "
+                                "fields, or '{field}' for nation fields. "
+                                "Province fields: production_value, population, "
+                                "fixed_expenditure, stockpile, base_production_growth, "
+                                "base_population_growth, tax_modifier. "
+                                "Nation fields: imperial_treasury, base_tax_rate, "
+                                "tribute_rate, fixed_expenditure."
+                            ),
+                        },
+                        "add": {
+                            "type": "string",
+                            "description": "One-time additive change (Decimal string). Cannot reduce field to 0.",
+                        },
+                        "factor": {
+                            "type": "string",
+                            "description": "Per-tick multiplicative factor (Decimal string, >= 0). Applied as field *= (1 + factor).",
+                        },
+                    },
+                    "required": ["target_path"],
+                },
+                "description": "List of effects. Each must have exactly one of 'add' or 'factor'.",
+            },
+            "remaining_ticks": {
+                "type": "integer",
+                "description": "Duration in ticks (1-48, where 4 ticks = 1 month).",
+            },
+        },
+        category="action",
+    )
+    async def create_incident(self, args: dict, event: TapeEvent) -> str:
+        import json
+
+        result = await self._server.create_incident(
+            title=args["title"],
+            effects=args["effects"],
+            remaining_ticks=args["remaining_ticks"],
+            description=args.get("description", ""),
+        )
+        if "error" in result:
+            return f"创建 incident 失败：{result['error']}"
         return json.dumps(result, ensure_ascii=False)
 
     @tool(

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -148,7 +148,7 @@ class StandardTools:
                             "type": "string",
                             "description": (
                                 "Dot-notation path: 'provinces.{id}.{field}' for province "
-                                "fields, or '{field}' for nation fields. "
+                                "fields, or 'nation.{field}' / '{field}' for nation fields. "
                                 "Province fields: production_value, population, "
                                 "fixed_expenditure, stockpile, base_production_growth, "
                                 "base_population_growth, tax_modifier. "

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -63,6 +63,20 @@ class FinishTaskSessionRequest(BaseModel):
     status: str = "completed"  # "completed" or "failed"
 
 
+class EffectRequest(BaseModel):
+    target_path: str  # e.g. "provinces.zhili.production_value"
+    add: str | None = None  # Decimal as string
+    factor: str | None = None  # Decimal as string
+
+
+class CreateIncidentRequest(BaseModel):
+    title: str
+    description: str = ""
+    effects: list[EffectRequest]
+    remaining_ticks: int
+    source: str = ""  # auto-filled with agent id if empty
+
+
 # ---------------------------------------------------------------------------
 # Dependency injection (same pattern as client.py)
 # ---------------------------------------------------------------------------
@@ -396,6 +410,174 @@ async def finish_task_session(
         x_agent_id, req.task_session_id, req.status,
     )
     return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Incident creation
+# ---------------------------------------------------------------------------
+
+_MAX_REMAINING_TICKS = 48  # 1 year
+
+
+def _load_data_scope(agent_id: str) -> dict[str, Any]:
+    """Load and return the data_scope.yaml for an agent."""
+    import yaml
+    from simu_server.config import settings
+
+    for base in (settings.agents_dir, settings.default_agents_dir):
+        scope_path = base / agent_id / "data_scope.yaml"
+        if scope_path.exists():
+            return yaml.safe_load(scope_path.read_text(encoding="utf-8")) or {}
+    return {}
+
+
+def _validate_effect(
+    effect: EffectRequest,
+    agent_id: str,
+    scope: dict[str, Any],
+    nation: Any,
+) -> str | None:
+    """Validate a single effect against data_scope and limits.
+
+    Returns an error message string, or None if valid.
+    """
+    from decimal import Decimal, InvalidOperation
+
+    parts = effect.target_path.split(".")
+
+    # --- Parse target path ---
+    if parts[0] == "provinces" and len(parts) == 3:
+        province_id, field_name = parts[1], parts[2]
+
+        # Province permission check
+        allowed_provinces = scope.get("provinces", [])
+        if allowed_provinces != "all" and province_id not in allowed_provinces:
+            return f"权限不足：agent {agent_id} 无权修改省份 {province_id} 的数据"
+
+        # Field permission check
+        allowed_fields = scope.get("fields", [])
+        if field_name not in allowed_fields:
+            return f"字段不允许：{agent_id} 的 data_scope 不包含省份字段 {field_name}"
+
+        # Get current value for validation
+        province = nation.provinces.get(province_id)
+        if province is None:
+            return f"省份不存在：{province_id}"
+        current = getattr(province, field_name, None)
+        if current is None or not isinstance(current, Decimal):
+            return f"字段无效：{field_name} 不是有效的数值字段"
+
+    elif len(parts) == 1:
+        field_name = parts[0]
+
+        # Nation field permission check
+        allowed_nation_fields = scope.get("nation_fields", [])
+        if field_name not in allowed_nation_fields:
+            return f"字段不允许：{agent_id} 的 data_scope 不包含国家级别字段 {field_name}"
+
+        current = getattr(nation, field_name, None)
+        if current is None or not isinstance(current, Decimal):
+            return f"字段无效：{field_name} 不是有效的国家级数值字段"
+
+    else:
+        return f"target_path 格式错误：{effect.target_path}（应为 'provinces.{{id}}.{{field}}' 或 '{{field}}'）"
+
+    # --- Value validation ---
+    if effect.add is not None and effect.factor is not None:
+        return "Effect 必须只有 add 或 factor 之一，不能同时设置"
+    if effect.add is None and effect.factor is None:
+        return "Effect 必须设置 add 或 factor 之一"
+
+    try:
+        if effect.add is not None:
+            add_val = Decimal(effect.add)
+            # Negative add cannot reduce field to 0 or below
+            if add_val < 0 and current + add_val <= 0:
+                return (
+                    f"数值溢出：add={effect.add} 会将 {effect.target_path} "
+                    f"（当前值 {current}）减至 0 或以下"
+                )
+        if effect.factor is not None:
+            factor_val = Decimal(effect.factor)
+            if factor_val < 0:
+                return f"factor 不能为负数：{effect.factor}"
+    except InvalidOperation:
+        return f"数值格式错误：add={effect.add}, factor={effect.factor}"
+
+    return None
+
+
+@router.post("/incident")
+async def create_incident(
+    req: CreateIncidentRequest,
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, Any]:
+    """Create a new incident with data_scope permission checks."""
+    from decimal import Decimal
+
+    from simu_shared.models import Effect, Incident
+
+    await _verify_agent(x_agent_id, x_callback_token)
+
+    engine = _get("engine")
+    if engine is None:
+        raise HTTPException(status_code=503, detail="Engine not initialized")
+
+    nation = engine.state.nation
+
+    # Validate remaining_ticks
+    if req.remaining_ticks < 1 or req.remaining_ticks > _MAX_REMAINING_TICKS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"remaining_ticks 必须在 1-{_MAX_REMAINING_TICKS} 之间",
+        )
+
+    if not req.effects:
+        raise HTTPException(status_code=400, detail="至少需要一个 effect")
+
+    # Load data scope
+    scope = _load_data_scope(x_agent_id)
+    if not scope:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Agent {x_agent_id} 没有 data_scope 配置",
+        )
+
+    # Validate each effect
+    errors: list[str] = []
+    for eff in req.effects:
+        err = _validate_effect(eff, x_agent_id, scope, nation)
+        if err:
+            errors.append(err)
+
+    if errors:
+        raise HTTPException(status_code=400, detail="; ".join(errors))
+
+    # Build and add incident
+    effects = []
+    for eff in req.effects:
+        kwargs: dict[str, Any] = {"target_path": eff.target_path}
+        if eff.add is not None:
+            kwargs["add"] = Decimal(eff.add)
+        if eff.factor is not None:
+            kwargs["factor"] = Decimal(eff.factor)
+        effects.append(Effect(**kwargs))
+
+    incident = Incident(
+        title=req.title,
+        description=req.description,
+        effects=effects,
+        remaining_ticks=req.remaining_ticks,
+        source=req.source or f"agent:{x_agent_id}",
+    )
+    engine.add_incident(incident)
+
+    logger.info(
+        "Agent %s created incident '%s' (%d effects, %d ticks)",
+        x_agent_id, req.title, len(effects), req.remaining_ticks,
+    )
+    return {"incident_id": incident.incident_id, "status": "created"}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -420,14 +420,35 @@ _MAX_REMAINING_TICKS = 48  # 1 year
 
 
 def _load_data_scope(agent_id: str) -> dict[str, Any]:
-    """Load and return the data_scope.yaml for an agent."""
+    """Load and return the data_scope.yaml for an agent.
+
+    Handles both the new flat format (provinces/fields/nation_fields at
+    top level) and the legacy V4 format (nested under skills.query_data).
+    Prefers default_agents_dir over agents_dir to ensure updates propagate.
+    """
     import yaml
     from simu_server.config import settings
 
-    for base in (settings.agents_dir, settings.default_agents_dir):
+    # Prefer default_agents (always up-to-date) over runtime agents (may be stale)
+    for base in (settings.default_agents_dir, settings.agents_dir):
         scope_path = base / agent_id / "data_scope.yaml"
         if scope_path.exists():
-            return yaml.safe_load(scope_path.read_text(encoding="utf-8")) or {}
+            raw = yaml.safe_load(scope_path.read_text(encoding="utf-8")) or {}
+            # If it has top-level provinces/fields, it's the new format
+            if "provinces" in raw or "fields" in raw or "nation_fields" in raw:
+                return raw
+            # Legacy format: extract from skills.query_data
+            query_data = raw.get("skills", {}).get("query_data", {})
+            if query_data:
+                return {
+                    "display_name": raw.get("display_name", ""),
+                    "provinces": query_data.get("provinces", []),
+                    "fields": [
+                        f.split(".")[0] for f in query_data.get("fields", [])
+                    ],
+                    "nation_fields": query_data.get("national", []),
+                }
+            return raw
     return {}
 
 
@@ -467,8 +488,8 @@ def _validate_effect(
         if current is None or not isinstance(current, Decimal):
             return f"字段无效：{field_name} 不是有效的数值字段"
 
-    elif len(parts) == 1:
-        field_name = parts[0]
+    elif (len(parts) == 1) or (len(parts) == 2 and parts[0] == "nation"):
+        field_name = parts[-1]  # handles both "{field}" and "nation.{field}"
 
         # Nation field permission check
         allowed_nation_fields = scope.get("nation_fields", [])
@@ -480,7 +501,7 @@ def _validate_effect(
             return f"字段无效：{field_name} 不是有效的国家级数值字段"
 
     else:
-        return f"target_path 格式错误：{effect.target_path}（应为 'provinces.{{id}}.{{field}}' 或 '{{field}}'）"
+        return f"target_path 格式错误：{effect.target_path}（应为 'provinces.{{id}}.{{field}}' 或 'nation.{{field}}'）"
 
     # --- Value validation ---
     if effect.add is not None and effect.factor is not None:
@@ -555,9 +576,15 @@ async def create_incident(
         raise HTTPException(status_code=400, detail="; ".join(errors))
 
     # Build and add incident
+    # Nation-level fields need "nation." prefix for the engine's path parser
+    nation_fields = {"imperial_treasury", "base_tax_rate", "tribute_rate", "fixed_expenditure"}
     effects = []
     for eff in req.effects:
-        kwargs: dict[str, Any] = {"target_path": eff.target_path}
+        path = eff.target_path
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in nation_fields:
+            path = f"nation.{parts[0]}"
+        kwargs: dict[str, Any] = {"target_path": path}
         if eff.add is not None:
             kwargs["add"] = Decimal(eff.add)
         if eff.factor is not None:


### PR DESCRIPTION
## Summary
- **Server**: `POST /api/callback/incident` — agents can create time-limited incidents with economic effects
- **SDK**: `create_incident` tool registered in StandardTools
- **data_scope.yaml**: Updated all 3 default agents to match V5 model fields (removed stale V4 fields)

## Permission & Validation
- Agent's `data_scope.yaml` controls which provinces and fields they can affect
- Negative `add` cannot reduce a field to 0 or below
- `factor` must be >= 0
- `remaining_ticks` must be 1-48
- All validation errors return detailed Chinese error messages to the agent

## data_scope Changes
| Agent | provinces | fields | nation_fields |
|-------|-----------|--------|---------------|
| governor_zhili | [zhili] | production_value, population, fixed_expenditure, stockpile, growth rates, tax_modifier | — |
| governor_jiangnan | [jiangnan] | same as above | — |
| minister_of_revenue | all | production_value, population, stockpile, tax_modifier | imperial_treasury, base_tax_rate, tribute_rate, fixed_expenditure |

## Test plan
- [x] 14 existing tests pass
- [ ] Manual: agent creates incident → verify effect applied on next tick
- [ ] Manual: agent tries unauthorized province → verify error returned
- [ ] Manual: agent tries negative add that would zero out field → verify error

🤖 Generated with [Claude Code](https://claude.com/claude-code)