### PR TITLE
fix: agent reply dst, self-send guard, tape event display

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -58,7 +58,9 @@ class BaseAgent:
 
         # Tools
         self.tools = ToolRegistry()
-        self._standard_tools = StandardTools(self.server, session_state=self.session_state)
+        self._standard_tools = StandardTools(
+            self.server, session_state=self.session_state, agent_id=config.agent_id,
+        )
         self.tools.register_provider(self._standard_tools)
         self.tools.register_provider(self)  # auto-register @tool methods on subclass
 
@@ -234,12 +236,13 @@ class BaseAgent:
             context=context,
             tape=self.tape,
             agent_id=self.agent_id,
+            server=self.server,
         )
 
-        # Record the agent response in local tape
+        # Record the agent response in local tape and push to server
         response_event = TapeEvent(
             src=f"agent:{self.agent_id}",
-            dst=event.dst,
+            dst=[event.src],
             event_type=EventType.RESPONSE,
             payload={"content": result.content},
             session_id=session_id,
@@ -248,6 +251,7 @@ class BaseAgent:
             invocation_id=event.invocation_id,
         )
         await self.tape.append(response_event)
+        await self.server.push_tape_event(response_event)
 
         # Handle session transitions triggered by tools
         if result.ended_by_tool == "create_task_session":
@@ -308,6 +312,9 @@ class BaseAgent:
         else:
             parts.append(self._task_dispatch_instructions())
 
+        # Always include reply instructions
+        parts.append(self._agent_reply_instructions())
+
         return "\n\n".join(parts)
 
     @staticmethod
@@ -356,6 +363,26 @@ class BaseAgent:
 4. 收到回复后，调用 `finish_task_session(result="张廷玉回复：...")`
 
 请立即开始执行任务。"""
+
+    @staticmethod
+    def _agent_reply_instructions() -> str:
+        """Instructions for replying to messages from other agents."""
+        return """## 回复其他官员的消息
+
+当你收到来自其他官员（agent）的消息时，你必须使用 `send_message` 工具回复对方，**不能只在内心生成回复**。
+
+重要规则：
+- **必须使用 `send_message`** 回复发送者，否则对方收不到你的回复。
+- **禁止给自己发消息** — `send_message` 的 `recipients` 中不能包含你自己的 agent_id。
+- 根据消息来源（`src`）确定回复对象。例如收到 `agent:governor_jiangnan` 的消息，就用 `send_message(recipients=["governor_jiangnan"], ...)` 回复。
+
+### 示例
+
+收到 `agent:governor_jiangnan` 发来的问候消息，正确的回复方式：
+
+调用 `send_message(recipients=["governor_jiangnan"], message="承蒙挂念，老夫身体尚好…")`
+
+**错误方式**：直接输出文字而不调用 `send_message` — 这样对方无法收到回复。"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -98,6 +98,26 @@ class ServerClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def push_tape_event(self, event: TapeEvent) -> None:
+        """Push an internal tape event to the Server's MessageStore for frontend display."""
+        try:
+            resp = await self._http.post(
+                "/api/callback/tape-event",
+                json={
+                    "event_id": event.event_id,
+                    "session_id": event.session_id,
+                    "src": event.src,
+                    "dst": event.dst,
+                    "event_type": event.event_type,
+                    "payload": event.payload,
+                    "timestamp": event.timestamp.isoformat(),
+                    "parent_event_id": event.parent_event_id,
+                },
+            )
+            resp.raise_for_status()
+        except Exception:
+            logger.warning("Failed to push tape event to server", exc_info=True)
+
     # ------------------------------------------------------------------
     # Task session management
     # ------------------------------------------------------------------

--- a/packages/sdk/simu_sdk/react.py
+++ b/packages/sdk/simu_sdk/react.py
@@ -21,6 +21,7 @@ from simu_sdk.tape.context import ContextWindow
 from simu_sdk.tools.registry import ToolRegistry, ToolResult
 
 if TYPE_CHECKING:
+    from simu_sdk.client import ServerClient
     from simu_sdk.tape.manager import TapeManager
 
 logger = logging.getLogger(__name__)
@@ -48,6 +49,7 @@ class ReActLoop:
         context: ContextWindow,
         tape: TapeManager | None = None,
         agent_id: str = "",
+        server: ServerClient | None = None,
     ) -> ReActResult:
         """Run the loop and return the final result."""
         messages = self._build_initial_messages(event, context)
@@ -74,9 +76,11 @@ class ReActLoop:
 
             # Record assistant reasoning + tool calls to tape
             if tape:
-                await self._record_tool_calls(
+                tape_evt = await self._record_tool_calls(
                     tape, event, response, agent_id,
                 )
+                if server and tape_evt:
+                    await server.push_tape_event(tape_evt)
 
             # Execute tool calls
             tool_results: list[dict[str, str]] = []
@@ -97,9 +101,11 @@ class ReActLoop:
 
                 # Record tool result to tape
                 if tape:
-                    await self._record_tool_result(
+                    tape_evt = await self._record_tool_result(
                         tape, event, tc, result, agent_id,
                     )
+                    if server and tape_evt:
+                        await server.push_tape_event(tape_evt)
 
                 if result.ends_loop:
                     return ReActResult(
@@ -134,7 +140,7 @@ class ReActLoop:
         event: TapeEvent,
         response: LLMResponse,
         agent_id: str,
-    ) -> None:
+    ) -> TapeEvent:
         """Record the assistant's reasoning and tool calls to tape."""
         calls_summary = [
             {"name": tc.name, "arguments": tc.arguments}
@@ -152,6 +158,7 @@ class ReActLoop:
             parent_event_id=event.event_id,
         )
         await tape.append(tape_event)
+        return tape_event
 
     @staticmethod
     async def _record_tool_result(
@@ -160,7 +167,7 @@ class ReActLoop:
         tc: ToolCall,
         result: ToolResult,
         agent_id: str,
-    ) -> None:
+    ) -> TapeEvent:
         """Record a single tool result (observation) to tape."""
         tape_event = TapeEvent(
             src=f"agent:{agent_id}",
@@ -175,6 +182,7 @@ class ReActLoop:
             parent_event_id=event.event_id,
         )
         await tape.append(tape_event)
+        return tape_event
 
     # ------------------------------------------------------------------
     # Message construction

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -38,9 +38,11 @@ class StandardTools:
         self,
         server: ServerClient,
         session_state: SessionStateManager | None = None,
+        agent_id: str = "",
     ) -> None:
         self._server = server
         self._session_state = session_state
+        self._agent_id = agent_id
 
     @tool(
         name="send_message",
@@ -73,6 +75,14 @@ class StandardTools:
         category="communication",
     )
     async def send_message(self, args: dict, event: TapeEvent) -> str | ToolResult:
+        # Block sending to self
+        recipients = args["recipients"]
+        if self._agent_id and self._agent_id in recipients:
+            return ToolResult(
+                output=f"Error: cannot send a message to yourself ({self._agent_id}).",
+                success=False,
+            )
+
         event_id = await self._server.post_message(
             recipients=args["recipients"],
             message=args["message"],

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -214,6 +214,44 @@ async def report_tool_result(
     return {"status": "ok"}
 
 
+class TapeEventRequest(BaseModel):
+    event_id: str
+    session_id: str
+    src: str
+    dst: list[str]
+    event_type: str
+    payload: dict
+    timestamp: str
+    parent_event_id: str | None = None
+
+
+@router.post("/tape-event")
+async def push_tape_event(
+    req: TapeEventRequest,
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, str]:
+    """Receive internal tape events (TOOL_CALL, TOOL_RESULT, RESPONSE) from agents."""
+    await _verify_agent(x_agent_id, x_callback_token)
+    msg_store = _get("message_store")
+
+    content = req.payload.get("content", "")
+    if not content:
+        content = json.dumps(req.payload, ensure_ascii=False, default=str)
+
+    msg = RoutedMessage(
+        message_id=req.event_id,
+        session_id=req.session_id,
+        src=req.src,
+        dst=req.dst,
+        content=content,
+        event_type=req.event_type,
+        origin_event_id=req.parent_event_id,
+    )
+    await msg_store.store(msg)
+    return {"status": "ok"}
+
+
 # ---------------------------------------------------------------------------
 # Data queries
 # ---------------------------------------------------------------------------

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -303,8 +303,7 @@ function toChatMessages(events: TapeEvent[]): TapeEvent[] {
 }
 
 function toTapeContextEvents(events: TapeEvent[]): TapeEvent[] {
-  return events
-    .filter((event) => !isRespondToPlayerToolResult(event));
+  return events;
 }
 
 function hasPendingReply(events: TapeEvent[], sessionId: string): boolean {


### PR DESCRIPTION
## Summary
- Fix response_event `dst` — replies now target the sender (`event.src`) instead of self (`event.dst`)
- Add agent reply prompt with few-shot: agents must use `send_message` to reply to other agents
- Hard-block `send_message` from sending to self (tool-level validation)
- Push TOOL_CALL/TOOL_RESULT/RESPONSE tape events to server via new `/api/callback/tape-event` endpoint
- Frontend tape view shows all events (removed `isRespondToPlayerToolResult` filter)

## Test plan
- [ ] "问问张廷玉身体如何" — minister_of_revenue should reply via `send_message` to the requesting agent, not to itself
- [ ] Verify `send_message(recipients=[self_agent_id])` returns error
- [ ] Frontend tape view shows TOOL_CALL, TOOL_RESULT, RESPONSE events alongside CHAT and AGENT_MESSAGE
- [ ] Verify `/api/tape/current` returns all event types including internal tape events

🤖 Generated with [Claude Code](https://claude.com/claude-code)