### PR TITLE
fix: reply blocking and task creator constraint

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -192,27 +192,23 @@ class BaseAgent:
         await self._process_queued_messages(session_id)
 
     def _try_clear_pending_reply(self, event: TapeEvent) -> bool:
-        """Check if this event clears a pending reply. Returns True if it did."""
+        """Clear pending reply matched by sender. Returns True if cleared."""
         session_id = event.session_id
-        replies = self.session_state._pending_replies.get(session_id, set())
-        if not replies:
-            return False
 
         # Try exact match first (parent_event_id matches a pending reply)
         origin = event.parent_event_id
-        if origin and origin in replies:
-            self.session_state.remove_pending_reply(session_id, origin)
-            return True
+        if origin:
+            replies = self.session_state._pending_replies.get(session_id, {})
+            if origin in replies:
+                self.session_state.remove_pending_reply(session_id, origin)
+                return True
 
-        # Fallback: any incoming AGENT_MESSAGE on a session with pending
-        # replies is treated as "the reply" — the replying agent's
-        # send_message creates a fresh event without parent_event_id.
-        if event.event_type == EventType.AGENT_MESSAGE:
-            first = next(iter(replies))
-            self.session_state.remove_pending_reply(session_id, first)
+        # Match by sender — the replying agent's send_message creates a
+        # fresh event without parent_event_id, so match by event.src.
+        if self.session_state.clear_reply_from(session_id, event.src):
             logger.info(
-                "Cleared pending reply %s on session %s (fallback match from %s)",
-                first, session_id, event.src,
+                "Cleared pending reply from %s on session %s",
+                event.src, session_id,
             )
             return True
 

--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -194,13 +194,28 @@ class BaseAgent:
     def _try_clear_pending_reply(self, event: TapeEvent) -> bool:
         """Check if this event clears a pending reply. Returns True if it did."""
         session_id = event.session_id
-        # Check if the origin_event_id matches a pending reply
+        replies = self.session_state._pending_replies.get(session_id, set())
+        if not replies:
+            return False
+
+        # Try exact match first (parent_event_id matches a pending reply)
         origin = event.parent_event_id
-        if origin:
-            replies = self.session_state._pending_replies.get(session_id, set())
-            if origin in replies:
-                self.session_state.remove_pending_reply(session_id, origin)
-                return True
+        if origin and origin in replies:
+            self.session_state.remove_pending_reply(session_id, origin)
+            return True
+
+        # Fallback: any incoming AGENT_MESSAGE on a session with pending
+        # replies is treated as "the reply" — the replying agent's
+        # send_message creates a fresh event without parent_event_id.
+        if event.event_type == EventType.AGENT_MESSAGE:
+            first = next(iter(replies))
+            self.session_state.remove_pending_reply(session_id, first)
+            logger.info(
+                "Cleared pending reply %s on session %s (fallback match from %s)",
+                first, session_id, event.src,
+            )
+            return True
+
         return False
 
     async def _process_queued_messages(self, session_id: str) -> None:
@@ -382,7 +397,14 @@ class BaseAgent:
 
 调用 `send_message(recipients=["governor_jiangnan"], message="承蒙挂念，老夫身体尚好…")`
 
-**错误方式**：直接输出文字而不调用 `send_message` — 这样对方无法收到回复。"""
+**错误方式**：直接输出文字而不调用 `send_message` — 这样对方无法收到回复。
+
+### 任务会话中的角色
+
+如果你在一个 task session 中收到消息，但你**不是**这个 task 的创建者（即消息是别人发来的询问），那么：
+- 你是任务**参与者**，不是创建者
+- **禁止调用 `finish_task_session` 或 `fail_task_session`** — 只有创建者有权结束任务
+- 你只需要用 `send_message` 回复发送者即可"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -90,7 +90,12 @@ class StandardTools:
             session_id=event.session_id,
         )
         if args.get("await_reply") and self._session_state:
-            self._session_state.add_pending_reply(event.session_id, event_id)
+            # Track who we're waiting for — each recipient becomes a pending reply
+            for r in recipients:
+                awaiting = f"agent:{r}" if not r.startswith("agent:") else r
+                self._session_state.add_pending_reply(
+                    event.session_id, event_id, awaiting_from=awaiting,
+                )
             return ToolResult(
                 output="Message sent. Waiting for reply — session paused.",
                 ends_loop=True,
@@ -375,7 +380,7 @@ class SessionStateManager:
 
     def __init__(self) -> None:
         self._pending_tasks: dict[str, set[str]] = {}  # session_id → {task_session_ids}
-        self._pending_replies: dict[str, set[str]] = {}  # session_id → {message_ids}
+        self._pending_replies: dict[str, dict[str, str]] = {}  # session_id → {msg_id: awaiting_from}
         self._message_queue: dict[str, list[Any]] = {}  # session_id → [events]
         self._parents: dict[str, str] = {}  # task_session_id → parent_session_id
         self._depths: dict[str, int] = {}  # session_id → depth (0 for root)
@@ -400,13 +405,26 @@ class SessionStateManager:
 
     # -- Pending replies --
 
-    def add_pending_reply(self, session_id: str, message_id: str) -> None:
-        self._pending_replies.setdefault(session_id, set()).add(message_id)
+    def add_pending_reply(
+        self, session_id: str, message_id: str, awaiting_from: str = "",
+    ) -> None:
+        self._pending_replies.setdefault(session_id, {})[message_id] = awaiting_from
 
     def remove_pending_reply(self, session_id: str, message_id: str) -> None:
         replies = self._pending_replies.get(session_id)
         if replies:
-            replies.discard(message_id)
+            replies.pop(message_id, None)
+
+    def clear_reply_from(self, session_id: str, sender: str) -> bool:
+        """Clear a pending reply matched by sender. Returns True if cleared."""
+        replies = self._pending_replies.get(session_id)
+        if not replies:
+            return False
+        for msg_id, awaiting in list(replies.items()):
+            if awaiting == sender:
+                replies.pop(msg_id)
+                return True
+        return False
 
     # -- Message queue --
 

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -289,7 +289,10 @@ class StandardTools:
 
         parent_id = self._session_state.get_parent(event.session_id)
         if parent_id is None:
-            return "Error: not in a task session, or parent session unknown."
+            return (
+                "Error: only the task creator can finish a task session. "
+                "You are a participant, not the creator of this task."
+            )
 
         await self._server.finish_task_session(
             task_session_id=event.session_id,
@@ -330,7 +333,10 @@ class StandardTools:
 
         parent_id = self._session_state.get_parent(event.session_id)
         if parent_id is None:
-            return "Error: not in a task session, or parent session unknown."
+            return (
+                "Error: only the task creator can fail a task session. "
+                "You are a participant, not the creator of this task."
+            )
 
         await self._server.finish_task_session(
             task_session_id=event.session_id,


### PR DESCRIPTION
## Summary
- Fix reply event blocking: `_try_clear_pending_reply` now falls back to clearing any pending reply when an `AGENT_MESSAGE` arrives on a blocked session, since reply events from other agents don't carry `parent_event_id`
- Hard constraint: `finish_task_session` / `fail_task_session` return explicit error for non-creators ("only the task creator can finish/fail")
- Prompt update: task participants told they must only reply via `send_message`, cannot call finish/fail

## Root cause (issue 1)
`send_message(await_reply=true)` stores the original event_id as pending reply. When the target agent replies via `send_message`, the server creates a NEW event with no `parent_event_id`. `_try_clear_pending_reply` required exact `parent_event_id` match → always returned False → reply queued → session permanently blocked.

## Test plan
- [ ] "问问张廷玉身体如何" — governor_jiangnan sends message, minister_of_revenue replies, governor_jiangnan receives reply and unblocks
- [ ] minister_of_revenue cannot call `finish_task_session` (gets explicit error)
- [ ] Task creator (governor_jiangnan) can still call `finish_task_session` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)