### PR TITLE
fix: RESPONSE event routing + player message display on session switch

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -162,7 +162,9 @@ class BaseAgent:
             return
 
         # Handle reply events — unblock session waiting for reply
-        if event.event_type == EventType.AGENT_MESSAGE:
+        # Both AGENT_MESSAGE (initiated messages) and RESPONSE (auto-replies)
+        # can serve as replies to a pending await_reply.
+        if event.event_type in (EventType.AGENT_MESSAGE, EventType.RESPONSE):
             cleared = self._try_clear_pending_reply(event)
             if cleared:
                 # Reply received — process queued messages if session unblocked
@@ -262,7 +264,17 @@ class BaseAgent:
             invocation_id=event.invocation_id,
         )
         await self.tape.append(response_event)
-        await self.server.push_tape_event(response_event)
+
+        # Route RESPONSE to destination agents for agent-to-agent replies.
+        # Only when the ReAct loop ended naturally (text output) — if a tool
+        # ended the loop (e.g. send_message already routed an AGENT_MESSAGE),
+        # routing the RESPONSE would be redundant.
+        should_route = (
+            result.ended_by_tool is None
+            and event.src.startswith("agent:")
+            and event.src != f"agent:{self.agent_id}"
+        )
+        await self.server.push_tape_event(response_event, route=should_route)
 
         # Handle session transitions triggered by tools
         if result.ended_by_tool == "create_task_session":
@@ -380,27 +392,32 @@ class BaseAgent:
         """Instructions for replying to messages from other agents."""
         return """## 回复其他官员的消息
 
-当你收到来自其他官员（agent）的消息时，你必须使用 `send_message` 工具回复对方，**不能只在内心生成回复**。
+当你收到来自其他官员（agent）的消息时，**直接输出文字回复即可**，系统会自动将你的回复发送给对方。
 
-重要规则：
-- **必须使用 `send_message`** 回复发送者，否则对方收不到你的回复。
-- **禁止给自己发消息** — `send_message` 的 `recipients` 中不能包含你自己的 agent_id。
-- 根据消息来源（`src`）确定回复对象。例如收到 `agent:governor_jiangnan` 的消息，就用 `send_message(recipients=["governor_jiangnan"], ...)` 回复。
+### send_message 与直接回复的区别
+
+- **直接回复（输出文字）**：用于**回应**收到的消息。你只需输出回复内容，系统会自动路由给发送者。
+- **`send_message` 工具**：用于**主动发起**新的沟通，例如向某位官员询问信息、下达指令等。
 
 ### 示例
 
 收到 `agent:governor_jiangnan` 发来的问候消息，正确的回复方式：
 
-调用 `send_message(recipients=["governor_jiangnan"], message="承蒙挂念，老夫身体尚好…")`
+直接输出："承蒙挂念，老夫身体尚好…"
 
-**错误方式**：直接输出文字而不调用 `send_message` — 这样对方无法收到回复。
+**不需要**调用 `send_message` — 系统会自动将你的回复发送给 governor_jiangnan。
+
+### 重要规则
+- 回复收到的消息时，直接输出文字，不要调用 `send_message`
+- 主动发起沟通时，使用 `send_message` 工具
+- **禁止给自己发消息** — `send_message` 的 `recipients` 中不能包含你自己的 agent_id
 
 ### 任务会话中的角色
 
 如果你在一个 task session 中收到消息，但你**不是**这个 task 的创建者（即消息是别人发来的询问），那么：
 - 你是任务**参与者**，不是创建者
 - **禁止调用 `finish_task_session` 或 `fail_task_session`** — 只有创建者有权结束任务
-- 你只需要用 `send_message` 回复发送者即可"""
+- 直接输出文字回复即可，系统会自动发送给对方"""
 
     # ------------------------------------------------------------------
     # Background tasks

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -98,8 +98,14 @@ class ServerClient:
         resp.raise_for_status()
         return resp.json()
 
-    async def push_tape_event(self, event: TapeEvent) -> None:
-        """Push an internal tape event to the Server's MessageStore for frontend display."""
+    async def push_tape_event(self, event: TapeEvent, route: bool = False) -> None:
+        """Push an internal tape event to the Server's MessageStore for frontend display.
+
+        If *route* is True and the event is a RESPONSE, the Server will also
+        deliver the event to destination agents via the normal event queue.
+        This enables automatic agent-to-agent reply routing without requiring
+        the replying agent to call ``send_message``.
+        """
         try:
             resp = await self._http.post(
                 "/api/callback/tape-event",
@@ -112,6 +118,7 @@ class ServerClient:
                     "payload": event.payload,
                     "timestamp": event.timestamp.isoformat(),
                     "parent_event_id": event.parent_event_id,
+                    "route": route,
                 },
             )
             resp.raise_for_status()

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -237,6 +237,7 @@ class TapeEventRequest(BaseModel):
     payload: dict
     timestamp: str
     parent_event_id: str | None = None
+    route: bool = False
 
 
 @router.post("/tape-event")
@@ -245,7 +246,12 @@ async def push_tape_event(
     x_agent_id: str = Header(...),
     x_callback_token: str = Header(...),
 ) -> dict[str, str]:
-    """Receive internal tape events (TOOL_CALL, TOOL_RESULT, RESPONSE) from agents."""
+    """Receive internal tape events (TOOL_CALL, TOOL_RESULT, RESPONSE) from agents.
+
+    When ``route=True`` and the event is a RESPONSE, the server also delivers
+    the event to destination agents via the normal queue — enabling automatic
+    agent-to-agent reply routing.
+    """
     await _verify_agent(x_agent_id, x_callback_token)
     msg_store = _get("message_store")
 
@@ -263,6 +269,26 @@ async def push_tape_event(
         origin_event_id=req.parent_event_id,
     )
     await msg_store.store(msg)
+
+    # Route RESPONSE events to destination agents when requested
+    if req.route and req.event_type == EventType.RESPONSE:
+        queue = _get("queue_controller")
+        if queue:
+            event = TapeEvent(
+                event_id=req.event_id,
+                src=req.src,
+                dst=req.dst,
+                event_type=req.event_type,
+                payload=req.payload,
+                session_id=req.session_id,
+                parent_event_id=req.parent_event_id,
+            )
+            for dst in req.dst:
+                if dst.startswith("agent:"):
+                    target_id = dst.removeprefix("agent:")
+                    if target_id != x_agent_id:
+                        await queue.enqueue(target_id, event)
+
     return {"status": "ok"}
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -290,11 +290,16 @@ function extractEventText(event: TapeEvent): string {
   return '';
 }
 
+function isPlayerMessage(src: string): boolean {
+  // Match all player sources: "player" (from API/DB), "player:web", "player:web:group"
+  return src === 'player' || src.startsWith('player:');
+}
+
 function toChatMessages(events: TapeEvent[]): TapeEvent[] {
   return events
     .filter((event) => {
-      // 显示玩家发送的消息（包括私聊 player:web 和群聊 player:web:group）
-      if (event.src === 'player:web' || event.src === 'player:web:group') {
+      // 显示玩家发送的消息（包括来自API的 "player" 和前端的 "player:web" / "player:web:group"）
+      if (isPlayerMessage(event.src)) {
         return normalizeEventType(event.type) === 'chat';
       }
       return isAgentReplyEvent(event);
@@ -311,7 +316,7 @@ function hasPendingReply(events: TapeEvent[], sessionId: string): boolean {
   let lastPlayerMessageIndex = -1;
 
   for (let i = 0; i < scoped.length; i += 1) {
-    if ((scoped[i].src === 'player:web' || scoped[i].src === 'player:web:group') && normalizeEventType(scoped[i].type) === 'chat') {
+    if (isPlayerMessage(scoped[i].src) && normalizeEventType(scoped[i].type) === 'chat') {
       lastPlayerMessageIndex = i;
     }
   }
@@ -1622,8 +1627,8 @@ export default function App() {
             {isValidSession && (
               <div className="space-y-3">
                 {chatMessages.map((event) => {
-                // 所有 player: 开头的消息都是玩家消息（包括私聊 player:web 和群聊 player:web:group）
-                const isPlayer = event.src.startsWith('player:');
+                // 所有 player 开头的消息都是玩家消息（API返回 "player"，前端生成 "player:web" / "player:web:group"）
+                const isPlayer = isPlayerMessage(event.src);
                 return (
                   <div key={event.event_id} className={`flex ${isPlayer ? 'justify-end' : 'justify-start'}`}>
                     <div


### PR DESCRIPTION
## Summary

- **RESPONSE 事件路由**：agent 回复其他 agent 时，文字输出自动作为 RESPONSE 事件路由到目标 agent。严格区分 `send_message`（发起）与 response（回应）。
- **Pending reply 检查**：`on_event` 现在同时检查 `AGENT_MESSAGE` 和 `RESPONSE` 事件来清除 pending reply。
- **Player 消息修复**：前端 `toChatMessages` 过滤器现在匹配所有 player 来源（`"player"`/`"player:web"`/`"player:web:group"`），修复切换会话后 player 消息消失的问题。

## Changes

### SDK (`agent.py`)
- `on_event`: 增加 `EventType.RESPONSE` 到 pending reply 检查
- `react()`: 当 ReAct 循环自然结束（文字输出，非工具终止）且目标是其他 agent 时，设置 `route=True` 让 RESPONSE 被路由
- 更新 prompt 指令：区分直接回复（输出文字）和主动发起（`send_message`）

### SDK (`client.py`)
- `push_tape_event` 新增 `route` 参数，控制是否路由 RESPONSE 到目标 agent

### Server (`callback.py`)
- `TapeEventRequest` 新增 `route` 字段
- `push_tape_event` endpoint：当 `route=True` 且事件类型为 RESPONSE 时，通过 queue_controller 将事件投递到目标 agent

### Frontend (`App.tsx`)
- 新增 `isPlayerMessage()` helper，匹配所有 player 来源
- `toChatMessages`、`hasPendingReply`、消息渲染均使用统一的 player 判断逻辑

## Test plan

- [ ] Agent A 向 Agent B 发消息（await_reply=true），B 输出文字回复 → A 收到 RESPONSE 事件，pending reply 被清除
- [ ] Agent A 向 Agent B 发消息（await_reply=true），B 使用 send_message 回复 → A 收到 AGENT_MESSAGE，RESPONSE 不重复路由
- [ ] 前端发送消息后切换到其他会话再切回 → player 消息正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)