### PR TITLE
fix: process reply in react loop and deduplicate player messages

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -167,8 +167,13 @@ class BaseAgent:
         if event.event_type in (EventType.AGENT_MESSAGE, EventType.RESPONSE):
             cleared = self._try_clear_pending_reply(event)
             if cleared:
-                # Reply received — process queued messages if session unblocked
-                await self._process_queued_messages(event.session_id)
+                if not self.session_state.is_blocked(event.session_id):
+                    # Fully unblocked — process the reply, then any queued messages
+                    await self.react(event)
+                    await self._process_queued_messages(event.session_id)
+                else:
+                    # Still waiting for more replies — queue the reply for later
+                    self.session_state.enqueue_message(event.session_id, event)
                 return
 
         # Session-level blocking: if the session has pending tasks/replies, queue the event

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -83,8 +83,8 @@ function formatTurn(turn: number): string {
 }
 
 function getSenderName(event: TapeEvent): string {
-  // 所有 player: 开头的消息都显示为"皇帝"
-  if (event.src.startsWith('player:')) return '皇帝';
+  // 所有 player 消息都显示为"皇帝"（API返回 "player"，前端生成 "player:web"）
+  if (isPlayerMessage(event.src)) return '皇帝';
   if (event.src.startsWith('agent:')) {
     const agentId = event.src.replace('agent:', '');
     if (agentId === 'governor_zhili') return '直隶巡抚';
@@ -344,7 +344,11 @@ function getEventTimeMs(event: TapeEvent): number {
 
 function isEquivalentEvent(left: TapeEvent, right: TapeEvent): boolean {
   if (left.session_id !== right.session_id) return false;
-  if (left.src !== right.src) return false;
+  // Normalize player sources: "player", "player:web", "player:web:group" are all equivalent
+  const leftIsPlayer = isPlayerMessage(left.src);
+  const rightIsPlayer = isPlayerMessage(right.src);
+  if (leftIsPlayer !== rightIsPlayer) return false;
+  if (!leftIsPlayer && left.src !== right.src) return false;
   if (!isEquivalentType(left.type, right.type)) return false;
 
   const leftText = extractEventText(left).trim();


### PR DESCRIPTION
## Summary

PR #66 的后续修复，解决 SolidYang 反馈的两个遗留问题：

- **Reply 事件未进入 react 循环**：pending reply 清除后，reply 事件本身没有被 `react()` 处理。agent 看不到回复内容，无法继续执行（如调用 `finish_task_session`）。现在 reply 到达后，先 `react(event)` 处理回复，再处理 queued messages。
- **Player 消息重复显示**：`isEquivalentEvent` 未归一化 player 来源（`"player"` vs `"player:web"`），导致 optimistic event 和 API event 无法去重。`getSenderName` 对 `src="player"` 显示为 "player" 而非 "皇帝"。现已统一使用 `isPlayerMessage()` 判断。

## Changes

### SDK (`agent.py`)
- Reply 清除后：如果 session 完全解除阻塞，先 `react(event)` 处理 reply，再 `_process_queued_messages`
- 如果仍有其他 pending（多 recipient），将 reply 入队等待

### Frontend (`App.tsx`)
- `isEquivalentEvent`: 归一化 player 来源进行去重
- `getSenderName`: 使用 `isPlayerMessage()` 统一显示 "皇帝"

## Test plan

- [ ] Agent A 向 B 发消息（await_reply=true），B 回复后 A 能看到回复内容并继续执行
- [ ] 切换会话再切回，player 消息只显示一条且名称为"皇帝"

🤖 Generated with [Claude Code](https://claude.com/claude-code)