### PR TITLE
fix: session title push + views/summaries debug mirrors

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -90,6 +90,8 @@ class BaseAgent:
             metadata_manager=self.metadata_manager,
             memory_store=self.memory_store,
             llm=self._summary_llm,
+            memory_dir=mirror_dir,
+            agent_id=config.agent_id,
         )
 
         # Tools
@@ -378,6 +380,7 @@ class BaseAgent:
             return
         title = await self.context_manager.generate_title(event)
         await self.metadata_manager.create_metadata(event.session_id, title)
+        await self.server.update_session_title(event.session_id, title)
         logger.info("Generated title for session %s: %s", event.session_id, title)
 
     async def _update_session_summary(self, session_id: str) -> None:

--- a/packages/sdk/simu_sdk/client.py
+++ b/packages/sdk/simu_sdk/client.py
@@ -98,6 +98,17 @@ class ServerClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def update_session_title(self, session_id: str, title: str) -> None:
+        """Push an LLM-generated session title to the Server."""
+        try:
+            resp = await self._http.post(
+                "/api/callback/session/title",
+                json={"session_id": session_id, "title": title},
+            )
+            resp.raise_for_status()
+        except Exception:
+            logger.warning("Failed to push session title to server", exc_info=True)
+
     async def push_tape_event(self, event: TapeEvent, route: bool = False) -> None:
         """Push an internal tape event to the Server's MessageStore for frontend display.
 
@@ -225,7 +236,9 @@ class ServerClient:
         logger.exception("Error processing event %s", event.event_id)
         if event.invocation_id:
             await self.complete_invocation(
-                event.invocation_id, status="failed", error=str(error),
+                event.invocation_id,
+                status="failed",
+                error=str(error),
             )
 
     # ------------------------------------------------------------------

--- a/packages/sdk/simu_sdk/tape/context.py
+++ b/packages/sdk/simu_sdk/tape/context.py
@@ -7,8 +7,10 @@ into ViewSegments and stored in ChromaDB for later retrieval.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from simu_shared.constants import EventType
@@ -61,6 +63,8 @@ class ContextManager:
         metadata_manager: TapeMetadataManager | None = None,
         memory_store: MemoryStore | None = None,
         llm: LLMProvider | None = None,
+        memory_dir: Path | None = None,
+        agent_id: str = "",
     ) -> None:
         self._tape = tape
         self._config = config
@@ -68,6 +72,8 @@ class ContextManager:
         self._metadata = metadata_manager
         self._store = memory_store
         self._llm = llm
+        self._memory_dir = memory_dir
+        self._agent_id = agent_id
 
     async def get_context(self, session_id: str) -> ContextWindow:
         """Return the most recent events, plus a summary of older ones."""
@@ -143,6 +149,9 @@ class ContextManager:
 
         if self._store:
             await self._store.upsert_view(view)
+
+        # Mirror to debug file
+        self._mirror_view(view)
 
         logger.info(
             "Compressed %d events [%d:%d] for session %s",
@@ -262,6 +271,9 @@ class ContextManager:
                 title=meta.title,
             )
 
+        # Mirror to debug file (overwrite)
+        self._mirror_summary(session_id, new_summary, title=meta.title if meta else "")
+
         logger.debug("Updated session summary for %s", session_id)
         return new_summary
 
@@ -295,3 +307,72 @@ class ContextManager:
                 "Title generation failed for session %s", event.session_id, exc_info=True
             )
             return event.session_id
+
+    # ------------------------------------------------------------------
+    # Debug mirrors — write views/summaries to data/memory/ for debugging
+    # ------------------------------------------------------------------
+
+    def _get_mirror_dir(self) -> Path | None:
+        """Return the agent's mirror directory, or None if mirroring is disabled."""
+        if not self._memory_dir or not self._agent_id:
+            return None
+        d = self._memory_dir / "agents" / self._agent_id
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _mirror_view(self, view: ViewSegment) -> None:
+        """Append a ViewSegment to views.jsonl for debugging."""
+        mirror_dir = self._get_mirror_dir()
+        if not mirror_dir:
+            return
+        try:
+            line = json.dumps(
+                {
+                    "view_id": view.view_id,
+                    "session_id": view.session_id,
+                    "start_index": view.start_index,
+                    "end_index": view.end_index,
+                    "summary": view.summary,
+                    "event_count": view.event_count,
+                },
+                ensure_ascii=False,
+            )
+            with open(mirror_dir / "views.jsonl", "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+        except Exception:
+            logger.warning("Failed to mirror view", exc_info=True)
+
+    def _mirror_summary(self, session_id: str, summary: str, *, title: str = "") -> None:
+        """Overwrite summaries.jsonl with current session summaries.
+
+        Unlike views.jsonl (append), this file is rewritten each time
+        so it always reflects the latest replacement summary per session.
+        """
+        mirror_dir = self._get_mirror_dir()
+        if not mirror_dir:
+            return
+        try:
+            path = mirror_dir / "summaries.jsonl"
+
+            # Read existing entries (one JSON object per line)
+            existing: dict[str, dict] = {}
+            if path.exists():
+                for raw_line in path.read_text(encoding="utf-8").splitlines():
+                    raw_line = raw_line.strip()
+                    if raw_line:
+                        obj = json.loads(raw_line)
+                        existing[obj["session_id"]] = obj
+
+            # Upsert current session
+            existing[session_id] = {
+                "session_id": session_id,
+                "title": title,
+                "summary": summary,
+            }
+
+            # Rewrite file
+            with open(path, "w", encoding="utf-8") as f:
+                for obj in existing.values():
+                    f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+        except Exception:
+            logger.warning("Failed to mirror summary", exc_info=True)

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -244,7 +244,11 @@ async def update_session_title(
     sm = _get("session_manager")
     ws_mgr = _get("ws_manager")
 
-    await sm.update_metadata(req.session_id, {"title": req.title})
+    # Merge title into existing metadata to avoid overwriting task fields
+    session = await sm.get(req.session_id)
+    existing = session.metadata if session else {}
+    existing["title"] = req.title
+    await sm.update_metadata(req.session_id, existing)
 
     # Broadcast to frontend so title updates live
     await ws_mgr.broadcast({

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -47,6 +47,11 @@ class InvocationCompleteRequest(BaseModel):
     error: str | None = None
 
 
+class UpdateTitleRequest(BaseModel):
+    session_id: str
+    title: str
+
+
 class CreateTaskSessionRequest(BaseModel):
     parent_session_id: str
     goal: str
@@ -225,6 +230,33 @@ async def report_tool_result(
     await _verify_agent(x_agent_id, x_callback_token)
     body = await request.json()
     logger.debug("Tool result from %s: %s", x_agent_id, body.get("tool_name"))
+    return {"status": "ok"}
+
+
+@router.post("/session/title")
+async def update_session_title(
+    req: UpdateTitleRequest,
+    x_agent_id: str = Header(...),
+    x_callback_token: str = Header(...),
+) -> dict[str, str]:
+    """Update a session's title (called by agent after LLM title generation)."""
+    await _verify_agent(x_agent_id, x_callback_token)
+    sm = _get("session_manager")
+    ws_mgr = _get("ws_manager")
+
+    await sm.update_metadata(req.session_id, {"title": req.title})
+
+    # Broadcast to frontend so title updates live
+    await ws_mgr.broadcast({
+        "kind": "session_title",
+        "data": {
+            "session_id": req.session_id,
+            "title": req.title,
+            "agent_id": x_agent_id,
+        },
+    })
+
+    logger.info("Agent %s set title for session %s: %s", x_agent_id, req.session_id, req.title)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- **Title 修复**：`_handle_first_event` 生成 title 后，通过新增的 `/api/callback/session/title` 端点推送到 Server，Server 更新 session metadata 并通过 WebSocket 广播到前端
- **Debug mirrors**：在 `data/memory/agents/{agent_id}/` 下新增 `views.jsonl`（追加写）和 `summaries.jsonl`（原地覆盖）两个调试文件，方便定位 memory 系统状态

## Changes
- `packages/server/simu_server/routes/callback.py`: 新增 `POST /api/callback/session/title` 端点
- `packages/sdk/simu_sdk/client.py`: 新增 `update_session_title()` 方法
- `packages/sdk/simu_sdk/agent.py`: `_handle_first_event` 调用 `server.update_session_title()`
- `packages/sdk/simu_sdk/tape/context.py`: 新增 `_mirror_view()` 和 `_mirror_summary()` 方法

## Test plan
- [ ] 15/15 memory tests pass（`uv run pytest tests/test_memory.py -k "not MemoryStore and not MemoryRetriever"`）
- [ ] 14/14 existing tests pass（`uv run pytest tests/test_game_state.py tests/test_smoke.py`）
- [ ] 启动后验证前端可看到 session title
- [ ] 验证 `data/memory/agents/{agent_id}/views.jsonl` 和 `summaries.jsonl` 正确写入

🤖 Generated with [Claude Code](https://claude.com/claude-code)