### PR TITLE
perf: run summary/title LLM calls in background to fix task session delay

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -325,8 +325,9 @@ class BaseAgent:
         )
         await self.server.push_tape_event(response_event, route=should_route)
 
-        # Update session summary after each response
-        await self._update_session_summary(session_id)
+        # Update session summary in background — avoid blocking the react
+        # loop on LLM summarization (which can take minutes).
+        asyncio.create_task(self._update_session_summary(session_id))
 
         # Handle session transitions triggered by tools
         if result.ended_by_tool == "create_task_session":

--- a/packages/sdk/simu_sdk/tape/manager.py
+++ b/packages/sdk/simu_sdk/tape/manager.py
@@ -7,6 +7,7 @@ the Server never touches Tape data.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -88,18 +89,23 @@ class TapeManager:
         await self._append_sqlite(event)
         self._append_memory_mirror(event)
 
-        # Fire callback on first event per session
+        # Fire callback on first event per session (non-blocking — title
+        # generation calls LLM and should not delay the react loop).
         if event.session_id not in self._seen_sessions:
             self._seen_sessions.add(event.session_id)
             if self.on_first_event:
-                try:
-                    await self.on_first_event(event)
-                except Exception:
-                    logger.warning(
-                        "on_first_event callback failed for session %s",
-                        event.session_id,
-                        exc_info=True,
-                    )
+                asyncio.create_task(self._safe_first_event_callback(event))
+
+    async def _safe_first_event_callback(self, event: TapeEvent) -> None:
+        """Run on_first_event in background with error handling."""
+        try:
+            await self.on_first_event(event)
+        except Exception:
+            logger.warning(
+                "on_first_event callback failed for session %s",
+                event.session_id,
+                exc_info=True,
+            )
 
     async def query(
         self,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -139,6 +140,8 @@ class TestTapeManagerExtensions:
         evt2 = _make_event(content="second", event_id="evt_2")
         await tape.append(evt1)
         await tape.append(evt2)
+        # Yield to event loop so background callbacks complete
+        await asyncio.sleep(0)
 
         # Callback should fire only once per session
         assert len(called_with) == 1
@@ -155,6 +158,8 @@ class TestTapeManagerExtensions:
         await tape.append(_make_event(session_id="s1", event_id="e1"))
         await tape.append(_make_event(session_id="s2", event_id="e2"))
         await tape.append(_make_event(session_id="s1", event_id="e3"))
+        # Yield to event loop so background callbacks complete
+        await asyncio.sleep(0)
 
         assert called_sessions == ["s1", "s2"]
 


### PR DESCRIPTION
## Summary
- **根因**：`_update_session_summary` 和 `on_first_event`（title生成）都是阻塞式 LLM 调用，在 react loop 中 await 执行，导致 task session 切换延迟约 4.5 分钟
- **修复**：两者均改为 `asyncio.create_task()` 后台执行，不阻塞事件处理和会话切换

## 分析
从 `data/memory/agents/governor_jiangnan/sessions/` 的 tape 分析：
- `15:51:27` create_task_session 返回
- `15:55:57` TASK_CREATED 事件到达（**4分30秒延迟**）
- 延迟原因：`react()` 在 `_enter_task_session()` 之前同步等待 `_update_session_summary()`，后者调用 LLM 生成摘要

## Changes
- `packages/sdk/simu_sdk/agent.py`: `_update_session_summary` 改为 `asyncio.create_task()`
- `packages/sdk/simu_sdk/tape/manager.py`: `on_first_event` 改为 `asyncio.create_task()`
- `tests/test_memory.py`: 添加 `await asyncio.sleep(0)` 等待后台回调完成

## Test plan
- [ ] 15/15 memory tests pass
- [ ] 14/14 existing tests pass
- [ ] 启动后验证 task session 切换不再有分钟级延迟

🤖 Generated with [Claude Code](https://claude.com/claude-code)