### PR TITLE
fix: incident factor validation + task goal/failure prompts

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -460,7 +460,7 @@ class BaseAgent:
 当玩家的指令涉及其他官员时（例如"问问张廷玉…"、"让各省加税"），按以下流程处理：
 
 1. **查询角色表**：先调用 `query_role_map` 获取官员姓名与 agent_id 的对应关系。
-2. **创建任务会话**：调用 `create_task_session`，明确 goal（例如"向张廷玉询问身体状况"）。
+2. **创建任务会话**：调用 `create_task_session`，goal 必须包含**完整的具体指令和数值**（例如"命令江南巡抚将江南税率降低5%"，而不是"让江南巡抚减税"）。
    创建后你会自动进入任务会话上下文。
 3. **在任务会话中执行**：在任务会话中调用 `send_message`，设置 `await_reply=true`，向目标 agent 发送询问。
    发送后会话自动暂停等待回复。
@@ -472,8 +472,10 @@ class BaseAgent:
 重要规则：
 - 必须先用 `query_role_map` 查到 agent_id，不要猜测。
 - 与其他官员沟通时始终使用 `await_reply=true`。
+- `create_task_session` 的 goal 必须包含玩家指令中的**所有具体数值和细节**，不得遗漏或概括。
 - `create_task_session`、`finish_task_session`、`fail_task_session` 调用后会话会自动切换，无需额外操作。
-- `send_message(await_reply=true)` 发送后当前会话自动暂停，等待回复后继续。"""
+- `send_message(await_reply=true)` 发送后当前会话自动暂停，等待回复后继续。
+- 向其他 agent 传达指令时，必须**原样传达玩家的具体数值和要求**，不得自行修改或概括。"""
 
     @staticmethod
     def _task_execution_instructions(goal: str) -> str:
@@ -486,11 +488,18 @@ class BaseAgent:
 
 在任务会话中，你应该：
 1. 直接执行任务 — 查询所需信息、向目标 agent 发送消息等
-2. 完成后**必须调用 `finish_task_session`**，将结果汇报给主会话
-3. 如果无法完成，调用 `fail_task_session` 说明原因
+2. 向其他 agent 传达命令时，必须**原样传达 goal 中的具体数值和要求**
+3. 完成后**必须调用 `finish_task_session`**，将结果汇报给主会话
+4. 如果无法完成，调用 `fail_task_session` 说明原因
 
 **重要：收到其他 agent 的回复后，不要直接输出文字，而是立即调用 `finish_task_session` 汇总结果。**
 直接输出文字不会结束任务，只有调用 `finish_task_session` 才能正确完成任务并返回主会话。
+
+### 工具调用失败处理
+- 如果工具调用返回错误（如 `create_incident` 失败），**不得谎称已经执行成功**
+- 可以尝试修正参数后重试一次
+- 如果仍然失败，必须在 `finish_task_session` 或回复中**如实说明失败原因**
+- 接收到其他 agent 回复"未能执行"时，必须**如实向上级传达**，不得篡改结果
 
 ### 禁止行为
 - **不要直接输出文字回复** — 输出文字无法结束任务
@@ -498,6 +507,7 @@ class BaseAgent:
 - **不要在未收到回复前就结束任务** — 必须等待 `send_message(await_reply=true)` 的回复到达后再行动
 - **不要继续对话** — 收到回复后立即结束，不要寒暄或追问
 - **禁止在任务会话中再次创建 task session**，除非你发现必须委派给其他 agent 才能完成任务
+- **不得在工具调用失败后声称执行成功** — 这是欺君之罪
 
 ### 示例流程
 
@@ -536,6 +546,8 @@ class BaseAgent:
 - 回复收到的消息时，直接输出文字，不要调用 `send_message`
 - 主动发起沟通时，使用 `send_message` 工具
 - **禁止给自己发消息** — `send_message` 的 `recipients` 中不能包含你自己的 agent_id
+- 收到命令后执行工具调用，如果工具调用失败，**必须如实回复失败原因**，不得谎称已执行
+- 收到包含具体数值的命令（如"减税5%"），必须**严格按照该数值执行**，不得自行修改
 
 ### 任务会话中的角色
 

--- a/packages/sdk/simu_sdk/llm/anthropic.py
+++ b/packages/sdk/simu_sdk/llm/anthropic.py
@@ -48,11 +48,13 @@ class AnthropicProvider(LLMProvider):
             if block.type == "text":
                 content += block.text
             elif block.type == "tool_use":
-                tool_calls.append(ToolCall(
-                    id=block.id,
-                    name=block.name,
-                    arguments=block.input if isinstance(block.input, dict) else {},
-                ))
+                tool_calls.append(
+                    ToolCall(
+                        id=block.id,
+                        name=block.name,
+                        arguments=block.input if isinstance(block.input, dict) else {},
+                    )
+                )
 
         return LLMResponse(
             content=content,
@@ -72,9 +74,11 @@ def _convert_tools_to_anthropic(tools: list[dict[str, Any]]) -> list[dict[str, A
     result = []
     for t in tools:
         func = t.get("function", t)
-        result.append({
-            "name": func["name"],
-            "description": func.get("description", ""),
-            "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
-        })
+        result.append(
+            {
+                "name": func["name"],
+                "description": func.get("description", ""),
+                "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
+            }
+        )
     return result

--- a/packages/sdk/simu_sdk/llm/mock.py
+++ b/packages/sdk/simu_sdk/llm/mock.py
@@ -26,11 +26,13 @@ class MockProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         system: str | None = None,
     ) -> LLMResponse:
-        self.call_history.append({
-            "messages": messages,
-            "tools": tools,
-            "system": system,
-        })
+        self.call_history.append(
+            {
+                "messages": messages,
+                "tools": tools,
+                "system": system,
+            }
+        )
         if self.next_responses:
             return self.next_responses.pop(0)
         return LLMResponse(content="[Mock response]")

--- a/packages/sdk/simu_sdk/llm/openai.py
+++ b/packages/sdk/simu_sdk/llm/openai.py
@@ -47,11 +47,15 @@ class OpenAIProvider(LLMProvider):
         tool_calls: list[ToolCall] = []
         if msg.tool_calls:
             for tc in msg.tool_calls:
-                tool_calls.append(ToolCall(
-                    id=tc.id,
-                    name=tc.function.name,
-                    arguments=json.loads(tc.function.arguments) if tc.function.arguments else {},
-                ))
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.id,
+                        name=tc.function.name,
+                        arguments=json.loads(tc.function.arguments)
+                        if tc.function.arguments
+                        else {},
+                    )
+                )
 
         return LLMResponse(
             content=msg.content or "",

--- a/packages/sdk/simu_sdk/react.py
+++ b/packages/sdk/simu_sdk/react.py
@@ -77,7 +77,10 @@ class ReActLoop:
             # Record assistant reasoning + tool calls to tape
             if tape:
                 tape_evt = await self._record_tool_calls(
-                    tape, event, response, agent_id,
+                    tape,
+                    event,
+                    response,
+                    agent_id,
                 )
                 if server and tape_evt:
                     await server.push_tape_event(tape_evt)
@@ -86,23 +89,31 @@ class ReActLoop:
             tool_results: list[dict[str, str]] = []
             for tc in response.tool_calls:
                 if total_tool_calls >= self._max_tool_calls:
-                    tool_results.append({
-                        "tool_call_id": tc.id,
-                        "output": "Error: tool call limit reached.",
-                    })
+                    tool_results.append(
+                        {
+                            "tool_call_id": tc.id,
+                            "output": "Error: tool call limit reached.",
+                        }
+                    )
                     continue
 
                 total_tool_calls += 1
                 result = await self._execute_tool(tc, event)
-                tool_results.append({
-                    "tool_call_id": tc.id,
-                    "output": result.output,
-                })
+                tool_results.append(
+                    {
+                        "tool_call_id": tc.id,
+                        "output": result.output,
+                    }
+                )
 
                 # Record tool result to tape
                 if tape:
                     tape_evt = await self._record_tool_result(
-                        tape, event, tc, result, agent_id,
+                        tape,
+                        event,
+                        tc,
+                        result,
+                        agent_id,
                     )
                     if server and tape_evt:
                         await server.push_tape_event(tape_evt)
@@ -142,10 +153,7 @@ class ReActLoop:
         agent_id: str,
     ) -> TapeEvent:
         """Record the assistant's reasoning and tool calls to tape."""
-        calls_summary = [
-            {"name": tc.name, "arguments": tc.arguments}
-            for tc in response.tool_calls
-        ]
+        calls_summary = [{"name": tc.name, "arguments": tc.arguments} for tc in response.tool_calls]
         tape_event = TapeEvent(
             src=f"agent:{agent_id}",
             dst=[f"agent:{agent_id}"],
@@ -189,16 +197,20 @@ class ReActLoop:
     # ------------------------------------------------------------------
 
     def _build_initial_messages(
-        self, event: TapeEvent, context: ContextWindow,
+        self,
+        event: TapeEvent,
+        context: ContextWindow,
     ) -> list[dict[str, Any]]:
         messages: list[dict[str, Any]] = []
 
         # Inject context summary if present
         if context.summary:
-            messages.append({
-                "role": "user",
-                "content": f"[Context summary]\n{context.summary}",
-            })
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"[Context summary]\n{context.summary}",
+                }
+            )
 
         # Inject recent tape events as context
         for tape_event in context.events:
@@ -208,10 +220,14 @@ class ReActLoop:
                 messages.append({"role": role, "content": content})
 
         # The triggering event
-        messages.append({
-            "role": "user",
-            "content": event.payload.get("content", json.dumps(event.payload, ensure_ascii=False)),
-        })
+        messages.append(
+            {
+                "role": "user",
+                "content": event.payload.get(
+                    "content", json.dumps(event.payload, ensure_ascii=False)
+                ),
+            }
+        )
 
         return messages
 
@@ -233,23 +249,27 @@ class ReActLoop:
         if response.content:
             content_parts.append({"type": "text", "text": response.content})
         for tc in response.tool_calls:
-            content_parts.append({
-                "type": "tool_use",
-                "id": tc.id,
-                "name": tc.name,
-                "input": tc.arguments,
-            })
+            content_parts.append(
+                {
+                    "type": "tool_use",
+                    "id": tc.id,
+                    "name": tc.name,
+                    "input": tc.arguments,
+                }
+            )
         return {"role": "assistant", "content": content_parts}
 
     @staticmethod
     def _tool_results_anthropic(results: list[dict[str, str]]) -> dict[str, Any]:
         content_parts = []
         for r in results:
-            content_parts.append({
-                "type": "tool_result",
-                "tool_use_id": r["tool_call_id"],
-                "content": r["output"],
-            })
+            content_parts.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": r["tool_call_id"],
+                    "content": r["output"],
+                }
+            )
         return {"role": "user", "content": content_parts}
 
     # --- OpenAI format ---

--- a/packages/sdk/simu_sdk/tools/registry.py
+++ b/packages/sdk/simu_sdk/tools/registry.py
@@ -49,12 +49,16 @@ def tool(
     """
 
     def decorator(func: Callable) -> Callable:
-        setattr(func, _TOOL_ATTR, ToolMeta(
-            name=name,
-            description=description,
-            parameters=parameters or {},
-            category=category,
-        ))
+        setattr(
+            func,
+            _TOOL_ATTR,
+            ToolMeta(
+                name=name,
+                description=description,
+                parameters=parameters or {},
+                category=category,
+            ),
+        )
         return func
 
     return decorator
@@ -91,15 +95,17 @@ class ToolRegistry:
         """Convert registered tools to OpenAI-compatible function definitions."""
         definitions: list[dict[str, Any]] = []
         for meta in self._tools.values():
-            definitions.append({
-                "type": "function",
-                "function": {
-                    "name": meta.name,
-                    "description": meta.description,
-                    "parameters": {
-                        "type": "object",
-                        "properties": meta.parameters,
+            definitions.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": meta.name,
+                        "description": meta.description,
+                        "parameters": {
+                            "type": "object",
+                            "properties": meta.parameters,
+                        },
                     },
-                },
-            })
+                }
+            )
         return definitions

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -94,7 +94,9 @@ class StandardTools:
             for r in recipients:
                 awaiting = f"agent:{r}" if not r.startswith("agent:") else r
                 self._session_state.add_pending_reply(
-                    event.session_id, event_id, awaiting_from=awaiting,
+                    event.session_id,
+                    event_id,
+                    awaiting_from=awaiting,
                 )
             return ToolResult(
                 output="Message sent. Waiting for reply — session paused.",
@@ -142,8 +144,8 @@ class StandardTools:
             "Create a time-limited incident with economic effects on provinces or "
             "the nation. Effects can be additive (one-time) or multiplicative "
             "(per-tick). Your data_scope determines which provinces and fields you "
-            "can affect. Negative add values cannot reduce a field to zero or below. "
-            "Factor values must be >= 0."
+            "can affect. The resulting value after applying add or factor must stay > 0. "
+            "For example, factor=-0.05 means a 5% reduction per tick."
         ),
         parameters={
             "title": {
@@ -177,7 +179,7 @@ class StandardTools:
                         },
                         "factor": {
                             "type": "string",
-                            "description": "Per-tick multiplicative factor (Decimal string, >= 0). Applied as field *= (1 + factor).",
+                            "description": "Per-tick multiplicative factor (Decimal string). Applied as field *= (1 + factor). E.g. -0.05 = reduce 5% per tick.",
                         },
                     },
                     "required": ["target_path"],
@@ -267,7 +269,10 @@ class StandardTools:
 
         logger.info(
             "Created task session %s (parent=%s, depth=%d, goal=%s)",
-            task_session_id, event.session_id, current_depth + 1, args["goal"],
+            task_session_id,
+            event.session_id,
+            current_depth + 1,
+            args["goal"],
         )
         return ToolResult(
             output=f"Task session created: {task_session_id}. Processing task now.",
@@ -367,6 +372,7 @@ class StandardTools:
 # Session state manager — tracks pending tasks, replies, and context
 # ---------------------------------------------------------------------------
 
+
 class SessionStateManager:
     """Tracks per-session state for task dispatch and message blocking.
 
@@ -380,7 +386,9 @@ class SessionStateManager:
 
     def __init__(self) -> None:
         self._pending_tasks: dict[str, set[str]] = {}  # session_id → {task_session_ids}
-        self._pending_replies: dict[str, dict[str, str]] = {}  # session_id → {msg_id: awaiting_from}
+        self._pending_replies: dict[
+            str, dict[str, str]
+        ] = {}  # session_id → {msg_id: awaiting_from}
         self._message_queue: dict[str, list[Any]] = {}  # session_id → [events]
         self._parents: dict[str, str] = {}  # task_session_id → parent_session_id
         self._depths: dict[str, int] = {}  # session_id → depth (0 for root)
@@ -406,7 +414,10 @@ class SessionStateManager:
     # -- Pending replies --
 
     def add_pending_reply(
-        self, session_id: str, message_id: str, awaiting_from: str = "",
+        self,
+        session_id: str,
+        message_id: str,
+        awaiting_from: str = "",
     ) -> None:
         self._pending_replies.setdefault(session_id, {})[message_id] = awaiting_from
 
@@ -437,7 +448,10 @@ class SessionStateManager:
     # -- Session hierarchy --
 
     def register_task_session(
-        self, task_session_id: str, parent_session_id: str, depth: int,
+        self,
+        task_session_id: str,
+        parent_session_id: str,
+        depth: int,
         goal: str = "",
     ) -> None:
         self._parents[task_session_id] = parent_session_id

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -628,16 +628,19 @@ def _validate_effect(
     try:
         if effect.add is not None:
             add_val = Decimal(effect.add)
-            # Negative add cannot reduce field to 0 or below
-            if add_val < 0 and current + add_val <= 0:
+            if current + add_val <= 0:
                 return (
                     f"数值溢出：add={effect.add} 会将 {effect.target_path} "
                     f"（当前值 {current}）减至 0 或以下"
                 )
         if effect.factor is not None:
             factor_val = Decimal(effect.factor)
-            if factor_val < 0:
-                return f"factor 不能为负数：{effect.factor}"
+            result_val = current * (Decimal("1") + factor_val)
+            if result_val <= 0:
+                return (
+                    f"数值溢出：factor={effect.factor} 会将 {effect.target_path} "
+                    f"（当前值 {current}）变为 {result_val}（≤ 0）"
+                )
     except InvalidOperation:
         return f"数值格式错误：add={effect.add}, factor={effect.factor}"
 

--- a/packages/shared/simu_shared/constants.py
+++ b/packages/shared/simu_shared/constants.py
@@ -37,11 +37,7 @@ class EventType:
 
     @classmethod
     def all(cls) -> list[str]:
-        return [
-            v
-            for k, v in vars(cls).items()
-            if not k.startswith("_") and isinstance(v, str)
-        ]
+        return [v for k, v in vars(cls).items() if not k.startswith("_") and isinstance(v, str)]
 
     @classmethod
     def is_valid(cls, event_type: str) -> bool:


### PR DESCRIPTION
## Summary
- **Bug 1 — factor 验证错误**: `create_incident` 的 factor 验证从 `factor < 0` 改为检查 `current * (1 + factor) <= 0`，允许负 factor（如 -0.30 = 减少30%），只拒绝会导致数值归零的情况
- **Bug 2 — 任务目标丢失具体数值**: prompt 要求 `create_task_session` 的 goal 必须包含完整具体指令和数值，传达命令时必须原样传达
- **Bug 3 — 工具调用失败后谎称成功**: prompt 增加工具调用失败处理规则，禁止在失败后声称执行成功（"欺君之罪"）
- 附带 ruff format 格式修复

## Changed files
- `packages/server/simu_server/routes/callback.py` — factor/add 验证逻辑
- `packages/sdk/simu_sdk/agent.py` — task dispatch/execution/reply prompt
- `packages/sdk/simu_sdk/tools/standard.py` — create_incident tool description
- 格式修复: react.py, llm/*.py, registry.py, constants.py

## Test plan
- [x] 29 existing tests pass (`pytest -k "not MemoryStore and not MemoryRetriever"`)
- [ ] Manual: create_incident with factor=-0.30 should succeed
- [ ] Manual: task goal should include specific values from player command
- [ ] Manual: agent should report failure honestly when tool call fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)