### PR TITLE
fix: modifier fields allow zero/negative, update tool description

### DIFF
--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -144,8 +144,15 @@ class StandardTools:
             "Create a time-limited incident with economic effects on provinces or "
             "the nation. Effects can be additive (one-time) or multiplicative "
             "(per-tick). Your data_scope determines which provinces and fields you "
-            "can affect. The resulting value after applying add or factor must stay > 0. "
-            "For example, factor=-0.05 means a 5% reduction per tick."
+            "can affect.\n\n"
+            "IMPORTANT field types:\n"
+            "- Absolute fields (production_value, population, stockpile, "
+            "imperial_treasury, base_tax_rate, tribute_rate, fixed_expenditure): "
+            "use 'factor' for percentage changes. Result must stay > 0.\n"
+            "- Modifier fields (tax_modifier, base_production_growth, "
+            "base_population_growth): these are additive adjustments, use 'add' "
+            "to change them (e.g. add='-0.005' to reduce tax by 0.5%). "
+            "factor on a zero-valued modifier has no effect."
         ),
         parameters={
             "title": {
@@ -166,9 +173,10 @@ class StandardTools:
                             "description": (
                                 "Dot-notation path: 'provinces.{id}.{field}' for province "
                                 "fields, or 'nation.{field}' / '{field}' for nation fields. "
-                                "Province fields: production_value, population, "
-                                "fixed_expenditure, stockpile, base_production_growth, "
-                                "base_population_growth, tax_modifier. "
+                                "Province absolute fields: production_value, population, "
+                                "fixed_expenditure, stockpile. "
+                                "Province modifier fields (use add): tax_modifier, "
+                                "base_production_growth, base_population_growth. "
                                 "Nation fields: imperial_treasury, base_tax_rate, "
                                 "tribute_rate, fixed_expenditure."
                             ),

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -631,6 +631,16 @@ def _validate_effect(
     if effect.add is None and effect.factor is None:
         return "Effect 必须设置 add 或 factor 之一"
 
+    # Modifier / growth fields can be zero or negative — skip overflow checks.
+    # Only "positive-only" fields (absolute values like production, population,
+    # treasury, tax rates) need the <= 0 guard.
+    _MODIFIER_FIELDS = {
+        "tax_modifier",
+        "base_production_growth",
+        "base_population_growth",
+    }
+    requires_positive = field_name not in _MODIFIER_FIELDS
+
     # Normalize target_path for comparison with active incidents.
     # Request paths may omit "nation." prefix; active incidents always have it.
     nation_fields = {"imperial_treasury", "base_tax_rate", "tribute_rate", "fixed_expenditure"}
@@ -654,27 +664,27 @@ def _validate_effect(
     try:
         if effect.add is not None:
             add_val = Decimal(effect.add)
-            # Simulate: current + all unapplied existing adds + new add
-            simulated = current + sum(existing_unapplied_adds) + add_val
-            if simulated <= 0:
-                return (
-                    f"数值溢出：add={effect.add} 会将 {effect.target_path} "
-                    f"（当前值 {current}，已有未生效 add 合计 "
-                    f"{sum(existing_unapplied_adds)}）减至 {simulated}（≤ 0）"
-                )
+            if requires_positive:
+                simulated = current + sum(existing_unapplied_adds) + add_val
+                if simulated <= 0:
+                    return (
+                        f"数值溢出：add={effect.add} 会将 {effect.target_path} "
+                        f"（当前值 {current}，已有未生效 add 合计 "
+                        f"{sum(existing_unapplied_adds)}）减至 {simulated}（≤ 0）"
+                    )
         if effect.factor is not None:
             factor_val = Decimal(effect.factor)
-            # Simulate one tick: current * product(1+existing_factor_i) * (1+new_factor)
-            simulated = current
-            for ef in existing_factors:
-                simulated *= Decimal("1") + ef
-            simulated *= Decimal("1") + factor_val
-            if simulated <= 0:
-                return (
-                    f"数值溢出：factor={effect.factor} 叠加已有修改后会将 "
-                    f"{effect.target_path}（当前值 {current}）变为 "
-                    f"{simulated}（≤ 0）"
-                )
+            if requires_positive:
+                simulated = current
+                for ef in existing_factors:
+                    simulated *= Decimal("1") + ef
+                simulated *= Decimal("1") + factor_val
+                if simulated <= 0:
+                    return (
+                        f"数值溢出：factor={effect.factor} 叠加已有修改后会将 "
+                        f"{effect.target_path}（当前值 {current}）变为 "
+                        f"{simulated}（≤ 0）"
+                    )
     except InvalidOperation:
         return f"数值格式错误：add={effect.add}, factor={effect.factor}"
 


### PR DESCRIPTION
## Summary
- `tax_modifier`、`base_production_growth`、`base_population_growth` 是加性修正字段，允许为 0 或负值，不应适用 `<= 0` 溢出检查
- 更新 `create_incident` tool description，明确区分绝对值字段（用 factor）和修正字段（用 add）
- 修复 @SolidYang 报告的 "factor=-0.05 on tax_modifier(0.0) 报错" 问题

## Changed files
- `packages/server/simu_server/routes/callback.py` — `_validate_effect` 新增 `_MODIFIER_FIELDS` 集合，跳过溢出检查
- `packages/sdk/simu_sdk/tools/standard.py` — tool description 区分 absolute/modifier 字段

## Test plan
- [x] 29 existing tests pass
- [ ] Manual: `create_incident` with `factor=-0.05` on `tax_modifier=0.0` should succeed
- [ ] Manual: `create_incident` with `add=-0.005` on `tax_modifier` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)