### PR TITLE
fix: allow tax_modifier zero/negative and fix prompt to use add

### DIFF
--- a/packages/sdk/simu_sdk/agent.py
+++ b/packages/sdk/simu_sdk/agent.py
@@ -436,10 +436,15 @@ class BaseAgent:
 当皇帝下达涉及经济、税收、生产等方面的具体指令时，你**必须调用 `create_incident` 工具**来执行，仅口头回复不会产生实际效果。
 
 ### 需要调用 `create_incident` 的场景
-- 调整税率（如"给直隶加税5%"）→ 使用 `tax_modifier` 字段
+- 调整税率（如"给直隶加税5%"）→ 对 `tax_modifier` 使用 `add`（注意：`tax_modifier` 是加性修正值，初始为 0，用 `add` 而非 `factor`）
 - 增减库存/拨款（如"拨银十万两赈灾"）→ 使用 `stockpile` 或 `imperial_treasury` 的 `add`
-- 影响生产/人口增长 → 使用 `base_production_growth` 或 `base_population_growth` 的 `factor`
+- 按比例调整生产/人口 → 对 `production_value` 或 `population` 使用 `factor`
 - 任何需要改变省份或国家数值的指令
+
+### add 与 factor 的区别
+- **add**：一次性加减固定值。适用于调整修正量（如 `tax_modifier`）、拨款（`stockpile`）等
+- **factor**：每 tick 按比例变化，`field *= (1 + factor)`。适用于持续性增减（如产值提升 10% → factor="0.10"）
+- **注意**：对当前值为 0 的字段使用 factor 无效（0 乘任何数仍为 0），此时应使用 add
 
 ### 关键规则
 - **先执行，再汇报**：收到指令后先调用 `create_incident` 创建 incident，再向皇帝回复执行结果
@@ -450,8 +455,8 @@ class BaseAgent:
 ### 示例
 
 皇帝指令："给直隶加税5%"
-正确做法：调用 `create_incident(title="直隶增税", effects=[{"target_path": "provinces.zhili.tax_modifier", "factor": "0.05"}], remaining_ticks=12, description="奉旨增加直隶税率5%")`
-错误做法：仅回复"遵旨，臣即刻办理"而不调用工具"""
+正确做法：调用 `create_incident(title="直隶增税", effects=[{"target_path": "provinces.zhili.tax_modifier", "add": "0.05"}], remaining_ticks=12, description="奉旨增加直隶税率5%")`
+错误做法：使用 factor 修改 tax_modifier（tax_modifier 初始值为 0，factor 无效）"""
 
     @staticmethod
     def _task_dispatch_instructions() -> str:

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -631,6 +631,14 @@ def _validate_effect(
     if effect.add is None and effect.factor is None:
         return "Effect 必须设置 add 或 factor 之一"
 
+    # Fields that are offsets/rates and can legitimately be zero or negative.
+    # Skip the "result <= 0" overflow check for these.
+    _allow_non_positive = {
+        "tax_modifier",
+        "base_production_growth",
+        "base_population_growth",
+    }
+
     # Normalize target_path for comparison with active incidents.
     # Request paths may omit "nation." prefix; active incidents always have it.
     nation_fields = {"imperial_treasury", "base_tax_rate", "tribute_rate", "fixed_expenditure"}
@@ -656,7 +664,7 @@ def _validate_effect(
             add_val = Decimal(effect.add)
             # Simulate: current + all unapplied existing adds + new add
             simulated = current + sum(existing_unapplied_adds) + add_val
-            if simulated <= 0:
+            if field_name not in _allow_non_positive and simulated <= 0:
                 return (
                     f"数值溢出：add={effect.add} 会将 {effect.target_path} "
                     f"（当前值 {current}，已有未生效 add 合计 "
@@ -669,7 +677,7 @@ def _validate_effect(
             for ef in existing_factors:
                 simulated *= Decimal("1") + ef
             simulated *= Decimal("1") + factor_val
-            if simulated <= 0:
+            if field_name not in _allow_non_positive and simulated <= 0:
                 return (
                     f"数值溢出：factor={effect.factor} 叠加已有修改后会将 "
                     f"{effect.target_path}（当前值 {current}）变为 "


### PR DESCRIPTION
## Summary
- **Validation**: Skip `<= 0` overflow check for modifier/growth fields (`tax_modifier`, `base_production_growth`, `base_population_growth`) — these are offsets that can legitimately be zero or negative
- **Prompt**: Fix `create_incident` example to use `add` instead of `factor` for `tax_modifier` (initial value 0.0, factor * 0 = 0). Added clear add vs factor explanation.

## Context
SolidYang reported: `factor=-0.05` on `provinces.zhili.tax_modifier` (current 0.0) fails with overflow error, even though the displayed tax rate is 10% (from `base_tax_rate`). Root cause: `tax_modifier` is an additive offset, not the tax rate itself.

## Test plan
- [ ] `create_incident` with `add=-0.05` on `tax_modifier` (current 0.0) should succeed
- [ ] `create_incident` with `add=0.05` on `tax_modifier` should succeed
- [ ] `create_incident` with negative `add` on `production_value` pushing it to 0 should still be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)