### PR TITLE
docs: refresh CLAUDE.md and ARCHITECTURE.md for V5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,171 +5,219 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-# Install dependencies
+# Install dependencies (uv workspace)
 uv sync
 
 # Run tests
 uv run pytest tests/                    # All tests
+uv run pytest tests/ -k "not MemoryStore and not MemoryRetriever"  # Skip ChromaDB tests
 uv run pytest tests/unit/               # Unit tests only
-uv run pytest tests/unit/event_bus/     # Single test directory
-uv run pytest tests/unit/event_bus/test_core.py  # Single file
-uv run pytest tests/unit/event_bus/test_core.py::test_name -v  # Single test
 
 # Lint and format
 uv run ruff check .
 uv run ruff format .
 
-# Run CLI game
-uv run simu-emperor
+# Start server
+uv run python -m simu_server
+
+# Start a single agent (usually done by server's ProcessManager)
+SIMU_SERVER_URL=http://localhost:8000 SIMU_AGENT_ID=governor_zhili \
+  SIMU_AGENT_TOKEN=xxx SIMU_CONFIG_PATH=data/agents/governor_zhili \
+  uv run python -m simu_sdk
 ```
 
 ## Architecture
 
-**V4.2: Tick-Based Real-Time Multi-Agent Architecture**
+**V5: Process-Per-Agent Multi-Agent Architecture**
 
-Tick-based emperor simulation game. The player is the emperor; AI agents play officials who may lie in reports and slack off when executing commands. All communication happens through an event bus — no direct function calls between modules. The game advances automatically via periodic ticks (1 tick = 1 week, 4 ticks = 1 month, 48 ticks = 1 year).
+Emperor simulation game. The player is the emperor; AI agents play court officials (governors, ministers). Each agent runs as an independent subprocess communicating with the central Server via SSE (events) and HTTP callbacks (actions).
 
 ### Core Principles
 
 | Principle | Description |
 |-----------|-------------|
-| **Event-Driven** | All interactions via EventBus (src/dst routing) |
-| **Fully Async** | asyncio-based, fire-and-forget by default |
-| **Tick-Based Timing** | Automatic tick progression (configurable interval, default 5s) |
-| **Unified Writes** | Only Engine can modify game state |
-| **Passive Agents** | Agents only respond to events, never initiate |
-| **Clean Architecture** | Adapter → Application → Core (no upward dependencies) |
+| **Process-per-Agent** | Each agent is an independent Python subprocess |
+| **SSE + HTTP Callback** | Server pushes events via SSE; agents call back via HTTP |
+| **Serial Dispatch** | QueueController ensures one invocation at a time per agent |
+| **ReAct Loop** | Agents use reason-act-observe cycles with LLM + tool calls |
+| **File-Driven Personality** | `soul.md` + `data_scope.yaml` define each agent |
+| **Tape-Based History** | Append-only JSONL + SQLite event logs per agent |
 
-### Directory Structure
+### Package Structure
 
 ```
-src/simu_emperor/
-├── event_bus/          # Event routing (EventBus, Event, EventType)
-├── engine/             # Game engine (Engine, TickCoordinator, ProvinceData/NationData, Incident/Effect)
-├── agents/             # AI officials
-│   ├── agent.py        # Agent base (event queue with backpressure)
-│   ├── react_loop.py   # ReAct loop for LLM tool-calling
-│   ├── system_prompts.py # System prompt assembly
-│   ├── skills/         # File-driven skill system (YAML frontmatter + markdown)
-│   └── tools/          # ToolRegistry, query/action/memory/task_session tools
-├── memory/             # Memory system (dual-write, DB-first reads, two-level search)
-├── application/        # Application layer (GameService, SessionService, AgentService, etc.)
-├── persistence/        # SQLite via aiosqlite (repositories + TapeRepository)
-├── llm/                # LLM providers (Anthropic, OpenAI, Mock)
-├── adapters/web/       # FastAPI server, WebSocket, message converter
-├── session/            # Session management, group chat
-└── common/             # Utilities
+packages/
+├── shared/         # Pydantic models (TapeEvent, NationData, Effect, etc.)
+│   └── simu_shared/
+│       ├── models.py       # All data models
+│       └── constants.py    # EventType enum
+│
+├── server/         # FastAPI backend — orchestration, state, routing
+│   └── simu_server/
+│       ├── app.py          # Startup, dependency wiring, dispatch function
+│       ├── routes/
+│       │   ├── client.py   # Frontend API (/api/command, /api/state, /ws, etc.)
+│       │   └── callback.py # Agent API (/api/callback/*, SSE, incidents)
+│       ├── services/
+│       │   ├── event_router.py       # Per-agent asyncio.Queue, SSE delivery
+│       │   ├── queue_controller.py   # Per-agent FIFO, serial dispatch
+│       │   ├── process_manager.py    # Subprocess spawn/terminate
+│       │   ├── session_manager.py    # Session CRUD (SQLite)
+│       │   ├── message_store.py      # Message persistence (SQLite + JSONL)
+│       │   ├── invocation_manager.py # Invocation lifecycle tracking
+│       │   └── group_store.py        # Agent groups
+│       ├── engine/
+│       │   ├── game_engine.py  # Facade: GameState + TickCoordinator + IncidentSystem
+│       │   ├── state.py        # NationData + ProvinceData (Decimal precision)
+│       │   ├── tick.py         # Turn advancement, growth, tax calculation
+│       │   └── incidents.py    # Time-limited economic effects (add/factor)
+│       └── stores/
+│           └── database.py     # SQLite + WAL mode
+│
+├── sdk/            # Agent runtime SDK
+│   └── simu_sdk/
+│       ├── agent.py        # BaseAgent: lifecycle, event dispatch, ReAct, prompts
+│       ├── client.py       # ServerClient: HTTP + SSE communication
+│       ├── config.py       # AgentConfig from environment variables
+│       ├── react.py        # ReActLoop: LLM → tool calls → observations
+│       ├── tools/
+│       │   ├── registry.py   # @tool decorator, ToolRegistry
+│       │   ├── standard.py   # send_message, query_state, create_incident, task sessions
+│       │   └── memory.py     # search_memory tool
+│       ├── tape/
+│       │   ├── manager.py    # TapeManager: JSONL + SQLite dual-write
+│       │   └── context.py    # ContextManager: sliding window, summaries, views
+│       ├── memory/
+│       │   ├── store.py      # MemoryStore (ChromaDB vector DB)
+│       │   ├── retriever.py  # MemoryRetriever (L1 session, L2 view search)
+│       │   └── metadata.py   # TapeMetadataManager (SQLite)
+│       └── llm/
+│           ├── base.py       # LLMProvider interface
+│           ├── anthropic.py  # Claude integration
+│           └── openai.py     # OpenAI/compatible integration
+│
+└── agents/         # Concrete agent configs (soul.md + data_scope.yaml per agent)
+
+web/                # React + Vite + TypeScript + Tailwind frontend
+├── src/App.tsx     # Main component, WebSocket, chat UI
+└── src/api/        # GameClient (REST + WebSocket)
 
 data/
-├── skills/             # Universal skill templates (v2.0 format)
 ├── default_agents/     # Agent templates (soul.md + data_scope.yaml)
-├── agent/              # Active agent workspace (runtime, mutable)
-├── memory/             # Dual-write storage (tape_meta.jsonl + per-agent sessions)
-└── initial_state_v4.json
+├── agent_templates/    # For dynamic agent generation
+└── memory/             # Runtime mirror (tape_meta.jsonl, per-agent sessions)
+```
 
-tests/
-├── unit/               # Mock all I/O and LLM
-├── integration/        # Real DB (in-memory), mock LLM
-└── e2e/                # Full game loop, mock LLM
+### Communication Flow
+
+**Player → Agent:**
+```
+Frontend POST /api/command
+  → TapeEvent(src=player, type=CHAT)
+  → QueueController.enqueue(agent_id, event)
+  → InvocationManager.create() → EventRouter.route()
+  → Agent receives via SSE /api/callback/events
+  → BaseAgent.on_event() → react(event)
+  → ReActLoop: LLM + tool calls
+  → RESPONSE → push_tape_event → post_message → WebSocket → Frontend
+```
+
+**Agent → Agent:**
+```
+Agent A: send_message(recipients=["agent_b"], await_reply=true)
+  → POST /api/callback/message → QueueController → EventRouter → Agent B SSE
+  → Agent B react() → text output → RESPONSE auto-routed back to A
+  → A's pending reply cleared → A continues processing
+```
+
+**Task Sessions:**
+```
+create_task_session(goal="...") → enters child session
+  → send_message(await_reply=true) → waits
+  → reply arrives → finish_task_session(result="...")
+  → TASK_FINISHED routed to parent session → agent reports to player
 ```
 
 ### Agent System
 
-Agents are file-driven AI officials. `soul.md` defines personality/behavior, `data_scope.yaml` defines data access permissions (per-skill field whitelist). Deception emerges from LLM reading soul.md — no hardcoded logic.
+Agents are file-driven AI officials. `soul.md` defines personality/behavior, `data_scope.yaml` defines data access permissions.
 
-**Available Tools:**
+**Standard Tools:**
 
-| Tool | Type | Description |
-|------|------|-------------|
-| `query_province` | Query | Query province data |
-| `query_nation` | Query | Query nation data |
-| `query_incidents` | Query | Query active incidents |
-| `send_message` | Action | Unified message sending (to agents or player) |
-| `write_memory` | Action | Short-term memory (recent/turn_*.md) |
-| `write_long_term_memory` | Action | Long-term memory (MEMORY.md) |
-| `update_soul` | Action | Personality evolution (soul.md append) |
-| `summarize_segment` | Action | Summarize memory segments via VectorStore |
-| `create_incident` | Action | Create time-limited game events |
-| `start_task_session` | Action | Create sub-session for tasks |
-| `end_task_session` | Action | End sub-session with summary |
+| Tool | Category | Description |
+|------|----------|-------------|
+| `send_message` | communication | Send to agents/player, optional `await_reply` |
+| `query_state` | communication | Query game state (provinces, treasury) |
+| `query_role_map` | communication | Look up agent IDs by official name |
+| `create_incident` | action | Create economic effects (add/factor on fields) |
+| `create_task_session` | session | Create sub-session for focused work |
+| `finish_task_session` | session | Complete task, return result to parent |
+| `fail_task_session` | session | Fail task with reason |
+| `search_memory` | memory | Vector search across past sessions |
 
-**Skill System** — Each skill is a markdown file with YAML frontmatter. Three-tier caching (Memory LRU → mtime → FS). Event-to-skill mapping: `CHAT → chat.md`, `AGENT_MESSAGE → receive_message.md`, `TICK_COMPLETED → on_tick_completed.md`. Supports `{{agent_id}}`, `{{turn}}`, `{{timestamp}}` placeholders.
+**System Prompt Construction** (`_build_system_prompt`):
+1. `soul.md` content (personality)
+2. `data_scope.yaml` (permissions)
+3. Action execution instructions (when to use `create_incident`)
+4. Task dispatch or task execution instructions (context-dependent)
+5. Agent reply instructions (text reply vs send_message)
 
-**Autonomous Memory** — Agents self-reflect every N ticks (default 4 = monthly). On reflection tick: `retrieve_memory → write_long_term_memory → (optional) update_soul`. Config: `AutonomousMemoryConfig` in `config.py`.
+### Session State Management
+
+`SessionStateManager` in each agent tracks:
+- `pending_tasks`: unfinished task sub-sessions
+- `pending_replies`: messages awaiting reply (from `await_reply=true`)
+- `message_queue`: events queued while session is blocked
+- Session hierarchy: parent/child relationships, nesting depth (max 5)
+
+When a session is blocked (has pending tasks or replies), new events are queued. When unblocked, queued events are drained through the ReAct loop.
 
 ### Memory System
 
-Dual-write event-based memory with DB-first retrieval.
+**Tape** (per-agent, per-session):
+- JSONL + SQLite dual-write
+- Optional mirror to `data/memory/` (via `SIMU_MEMORY_DIR`)
 
-**Write Path:** `Agent event → TapeWriter → tape.jsonl + TapeRepository (SQLite tape_events)`
+**Context Window**:
+- Sliding window with auto-compression into ViewSegments
+- Session summaries generated by LLM after each response
+- Views stored in ChromaDB for cross-session retrieval
 
-**Read Path:** `ContextManager → TapeRepository (DB-first) → JSONL fallback`
+**Memory Retrieval** (two-level):
+- L1: Search across sessions by title/summary
+- L2: Search within sessions for specific views
 
-**Search Path (cross-session):**
-- L1: TapeMetadataIndex — keyword search on session titles
-- L1.5: VectorStore (ChromaDB) — semantic search with retry
-- L2: SegmentSearcher — event content retrieval
+### Engine & Economic Model
 
-**Context Management:** Sliding window with auto-summarization (8000 token threshold, keeps 20 recent events after compaction).
-
-### Event System
-
-```json
-{
-    "event_id": "evt_20260226120000_a1b2c3d4",
-    "src": "player",
-    "dst": ["agent:revenue_minister"],
-    "type": "command",
-    "payload": {"intent": "adjust_tax", "province": "zhili", "rate": 0.05}
-}
+**Tick** (manual trigger via `POST /api/state/tick`):
+```
+TickCoordinator.tick()
+  → Apply base growth (production, population)
+  → Apply active Incident effects (add: one-time, factor: per-tick)
+  → Calculate tax: production × (base_tax_rate + tax_modifier)
+  → Calculate surplus, remittance, treasury
+  → Decrement incident remaining_ticks, expire completed
 ```
 
-**ID Naming:** Player: `"player"`, Agent: `"agent:{agent_id}"`, TickCoordinator: `"system:tick_coordinator"`, Broadcast: `"*"`
+**Key Fields:**
+- Province: `production_value`, `population`, `fixed_expenditure`, `stockpile`, `tax_modifier`, `base_production_growth`, `base_population_growth`
+- Nation: `imperial_treasury`, `base_tax_rate`, `tribute_rate`, `fixed_expenditure`
+- `tax_modifier` is an additive offset (initial 0.0), not the tax rate itself
 
-**Event Types:** `command` (Player→Agent), `query` (Player→Agent), `chat` (Player→Agent), `response` (Agent→Player), `agent_message` (Agent→Agent), `tick_completed` (TickCoordinator→*)
+### Event Types
 
-**Tape Event Types:** `USER_QUERY`, `TOOL_CALL`, `TOOL_RESULT`, `RESPONSE`, `GAME_EVENT`
-
-### Engine & Tick Flow
-
-```
-TickCoordinator timer → Engine.apply_tick()
-  → Apply growth rates (production ×1.01, population ×1.005)
-  → Apply active Effects (add: one-time, factor: per-tick multiplier)
-  → Calculate tax/treasury
-  → Refresh Incidents (decrement remaining_ticks, remove expired)
-  → Publish tick_completed event to all agents
-```
-
-### Session State Isolation
-
-Every agent maintains independent state per session. All state checks/mutations scoped to calling agent.
-
-- `agent_states: dict[str, str]` — per-agent (`ACTIVE` / `WAITING_REPLY` / `FINISHED` / `FAILED`)
-- `pending_async_replies: dict[str, int]` — per-agent async reply counter
-- Cross-session messages: only the sender's counter increments, receiver processes normally
-
-### Import Rules
-
-```python
-# ✅ Upper imports lower
-from simu_emperor.event_bus.core import EventBus
-from simu_emperor.agents.agent import Agent
-
-# ❌ Lower must NOT import upper
-from simu_emperor.cli.app import EmperorCLI  # core must not import cli
-```
-
-### Key Patterns
-
-- **Pydantic v2** with `Decimal` precision for game data
-- **Event sourcing:** Immutable append-only JSONL logs
-- **Dual-write:** TapeWriter writes to both JSONL and SQLite
-- **DB-first reads:** ContextManager reads from SQLite, falls back to JSONL
-- **ToolRegistry class** (not _function_handlers dict)
-- **Event queue backpressure:** asyncio.Queue with configurable max_size
-- **Deterministic engine:** Random functions accept seeded `random.Random`
-- **Repository pattern:** All data access through Repository interface
+| Type | Direction | Description |
+|------|-----------|-------------|
+| `CHAT` | player → agent | Player command |
+| `AGENT_MESSAGE` | agent → agent | Initiated communication |
+| `RESPONSE` | agent → agent/player | Auto-routed reply |
+| `TASK_CREATED` | agent → self | Synthetic event for new task |
+| `TASK_FINISHED` | server → agent | Task completed |
+| `TASK_FAILED` | server → agent | Task failed |
+| `TOOL_CALL` | agent → tape | ReAct loop tool invocation |
+| `TOOL_RESULT` | agent → tape | Tool execution result |
+| `SHUTDOWN` | server → agent | Graceful shutdown |
+| `RELOAD_CONFIG` | server → agent | Hot-reload personality |
 
 ## Coding Standards
 
@@ -184,35 +232,36 @@ if not role_map_path.exists():
 
 # ✅ CORRECT
 if not role_map_path.exists():
-    return "❌ 无法查询官员信息：role_map.md 文件不存在"
+    return "无法查询官员信息：role_map 文件不存在"
 ```
 
-Acceptable fallbacks: testing/mock mode, feature flags with consent, cached data with staleness warning.
+### Key Patterns
 
-### Logging
+- **Pydantic v2** with `Decimal` precision for game data
+- **Event sourcing:** Append-only JSONL + SQLite tape
+- **@tool decorator** for registering agent tools
+- **ToolResult** with `ends_loop=True` for session-switching tools
+- **Hot-reload:** `soul.md` / `data_scope.yaml` changes auto-detected
+- **asyncio throughout:** All I/O is async
 
-- Structured logging with `request_id` / `event_id` for traceability
-- Levels: DEBUG (dev), INFO (normal), WARNING (recoverable), ERROR (failures)
+### Import Rules
+
+Packages have strict dependency directions:
+```
+shared ← sdk ← agents
+shared ← server
+```
+SDK and server do NOT depend on each other — they communicate via HTTP/SSE.
 
 ## Development Workflow
 
-1. Read relevant design docs in `.prd/` and `.design/`
-2. Check existing tests for patterns
-3. Write unit tests before implementation (TDD)
-4. Run `uv run ruff check .` and `uv run pytest` before committing
-5. Update this CLAUDE.md if architecture changes
+1. Check existing tests for patterns
+2. Run `uv run ruff check .` and `uv run pytest` before committing
+3. Use `develop-v5` as the primary development branch
+4. Create feature/fix branches from `develop-v5`
+5. PR review required before merge
 
 ### Design Documents
 
-- `.prd/V2_PRD.md` — Product requirements
-- `.design/V2_TDD.md` — Technical design
-- `.design/V2_SKILL_TOOL_REFACTOR_DESIGN.md` — Skill system design
-- `.design/V3_MEMORY_SYSTEM_SPEC.md` — Memory system spec
-- `.design/V4.2_PERSISTENCE_ENHANCEMENT.md` — Dual-write, DB-first patterns
-
-## Testing Strategy
-
-- **Unit tests:** Mock all I/O and LLM calls. Test pure logic.
-- **Integration tests:** Real database (in-memory), mock LLM. Test event flows.
-- **E2E tests:** Full game loop, mock LLM. Test multi-turn scenarios.
-- **No external dependencies:** All tests runnable without API keys.
+- `docs/architecture/ARCHITECTURE.md` — V5 architecture details
+- `docs/research/v6-architecture-research.md` — Future architecture research

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -39,7 +39,10 @@
 │  │                  Services Layer                        │ │
 │  │  QueueController    EventRouter    InvocationManager   │ │
 │  │  SessionManager     MessageStore   ProcessManager      │ │
-│  │  AgentRegistry      GroupStore     WSManager           │ │
+│  │  GroupStore          WSManager                         │ │
+│  │                                                       │ │
+│  │  agents/                                              │ │
+│  │  AgentRegistry                                        │ │
 │  └───────────────────────────────────────────────────────┘ │
 │                                                             │
 │  ┌───────────────────────────────────────────────────────┐ │
@@ -235,7 +238,7 @@ while iterations < max_iterations:
 4. 任务派发指令 / 任务执行指令 — 根据会话类型
 5. 消息回复指令 — 区分 send_message 与直接文字回复
 
-### 3.5 SessionStateManager
+### 3.5 SessionStateManager（定义于 `tools/standard.py`）
 
 每个 Agent 内部维护的会话状态：
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,354 +1,392 @@
-# 皇帝模拟器 V4 - 架构说明文档
+# 皇帝模拟器 V5 - 架构说明文档
 
 ## 概述
 
-皇帝模拟器（Simu-Emperor）是一款基于事件驱动的多 Agent 回合制策略游戏。玩家扮演皇帝，AI 扮演朝廷官员，通过事件总线进行通信。
+皇帝模拟器（Simu-Emperor）是一款基于 Process-per-Agent 架构的多 Agent 策略游戏。玩家扮演皇帝，AI Agent 扮演朝廷官员（巡抚、尚书等），各自运行在独立进程中，通过中央 Server 进行通信和协调。
 
 ### 核心特性
 
-- **事件驱动架构**：所有模块通过 EventBus 进行异步通信
-- **Tick 游戏循环**：自动推进游戏时间（1 tick = 1 周）
-- **文件驱动 Agent**：通过 soul.md 和 data_scope.yaml 定义 AI 官员
-- **分层记忆系统**：支持短期记忆、长期记忆和跨会话检索
-- **Clean Architecture**：应用层与协议层分离，支持多种适配器
+- **Process-per-Agent**：每个 Agent 是独立的 Python 子进程
+- **SSE + HTTP Callback**：Server 通过 SSE 推送事件，Agent 通过 HTTP 回调执行操作
+- **ReAct 推理循环**：Agent 使用 LLM 进行 reason-act-observe 循环
+- **文件驱动 Agent**：通过 `soul.md` 和 `data_scope.yaml` 定义 AI 官员
+- **Tape 事件溯源**：JSONL + SQLite 双写，支持向量检索的记忆系统
+- **Task Session**：层级任务会话，支持多 Agent 协作
 
 ---
 
 ## 1. 系统架构
 
-### 1.1 分层架构
+### 1.1 总体架构
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                     Adapter Layer (适配器层)                  │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │     Web      │  │              │  │   Future...  │      │
-│  │   Adapter    │  │              │  │              │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-└────────────────────────────┬────────────────────────────────┘
-                             │ 仅协议转换
-                             ▼
+│                      Web Frontend                           │
+│              React + Vite + TypeScript + Tailwind            │
+│         WebSocket (/ws)          REST (/api/*)              │
+└──────────┬──────────────────────────┬───────────────────────┘
+           │ real-time push           │ commands/queries
+           ▼                          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                   Application Layer (应用层)                 │
-│  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐   │
-│  │ GameService   │  │ SessionService│  │ AgentService  │   │
-│  └───────────────┘  └───────────────┘  └───────────────┘   │
-│  ┌───────────────┐  ┌───────────────┐                       │
-│  │ GroupChatSvc  │  │ MessageService│                       │
-│  └───────────────┘  └───────────────┘                       │
-└────────────────────────────┬────────────────────────────────┘
-                             │ 业务逻辑
-                             ▼
+│                    FastAPI Server                            │
+│                                                             │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐ │
+│  │ client.py    │  │ callback.py  │  │  WebSocket Mgr    │ │
+│  │ (Frontend)   │  │ (Agent API)  │  │  (broadcast)      │ │
+│  └──────┬───────┘  └──────┬───────┘  └───────────────────┘ │
+│         │                 │                                 │
+│  ┌──────▼─────────────────▼──────────────────────────────┐ │
+│  │                  Services Layer                        │ │
+│  │  QueueController    EventRouter    InvocationManager   │ │
+│  │  SessionManager     MessageStore   ProcessManager      │ │
+│  │  AgentRegistry      GroupStore     WSManager           │ │
+│  └───────────────────────────────────────────────────────┘ │
+│                                                             │
+│  ┌───────────────────────────────────────────────────────┐ │
+│  │                   Game Engine                         │ │
+│  │  GameState    TickCoordinator    IncidentSystem       │ │
+│  └───────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+           │ SSE event stream              ▲ HTTP callbacks
+           ▼                               │
 ┌─────────────────────────────────────────────────────────────┐
-│                       Core Layer (核心层)                    │
-│  ┌─────────┐  ┌─────────┐  ┌──────────┐  ┌──────────────┐ │
-│  │  Engine │  │ Agents  │  │ EventBus │  │ Repository   │ │
-│  └─────────┘  └─────────┘  └──────────┘  └──────────────┘ │
+│              Agent Processes (独立子进程)                     │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │                    BaseAgent (SDK)                   │   │
+│  │  ServerClient ◄── SSE /api/callback/events          │   │
+│  │  on_event() → SessionStateManager → react(event)    │   │
+│  │  ReActLoop: LLM ↔ Tool Calls ↔ Observations        │   │
+│  │  TapeManager + ContextManager + MemoryStore         │   │
+│  │  soul.md + data_scope.yaml (personality/permissions) │   │
+│  └─────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### 1.2 模块依赖规则
+### 1.2 四个包的职责
 
-| 规则 | 说明 |
+| 包 | 路径 | 职责 |
+|---|---|---|
+| **shared** | `packages/shared/` | Pydantic 数据模型（TapeEvent, NationData, Effect 等），EventType 常量 |
+| **server** | `packages/server/` | FastAPI 服务、事件路由、队列调度、游戏引擎、进程管理、WebSocket |
+| **sdk** | `packages/sdk/` | Agent 运行时：ReAct 循环、LLM 抽象、工具注册、Tape 持久化、Memory 系统 |
+| **agents** | `packages/agents/` | 具体 Agent 配置（`soul.md` + `data_scope.yaml`） |
+
+### 1.3 包依赖规则
+
+```
+shared ← sdk ← agents
+shared ← server
+```
+
+SDK 和 Server 之间**不存在代码依赖** — 它们通过 HTTP/SSE 协议通信。
+
+---
+
+## 2. Server 模块
+
+### 2.1 路由层
+
+#### client.py — 前端 API
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/api/command` | POST | 发送玩家指令，路由到目标 Agent |
+| `/api/sessions` | GET/POST | 会话管理 |
+| `/api/sessions/select` | POST | 切换当前会话 |
+| `/api/state` | GET | 获取完整游戏状态 |
+| `/api/overview` | GET | 获取帝国概况 |
+| `/api/state/tick` | POST | 手动触发 tick |
+| `/api/agents` | GET | 获取已注册 Agent 列表 |
+| `/api/incidents` | GET | 获取活跃 Incident 列表 |
+| `/api/tape/current` | GET | 获取当前会话 tape 事件 |
+| `/api/tape/subsessions` | GET | 获取子会话列表 |
+| `/api/groups` | GET/POST | Agent 分组管理 |
+| `/ws` | WebSocket | 实时事件推送 |
+
+#### callback.py — Agent 回调 API
+
+所有请求携带 `X-Agent-Id` 和 `X-Callback-Token` 头：
+
+| 端点 | 方法 | 功能 |
+|------|------|------|
+| `/api/callback/register` | POST | Agent 注册（进程启动后） |
+| `/api/callback/heartbeat` | POST | 心跳 |
+| `/api/callback/status` | POST | 状态变更（停止） |
+| `/api/callback/events` | GET (SSE) | 事件流推送 |
+| `/api/callback/message` | POST | Agent 发送消息 |
+| `/api/callback/state` | GET | 查询游戏状态 |
+| `/api/callback/role-map` | GET | 查询官员-AgentID 映射 |
+| `/api/callback/tape-event` | POST | 推送内部事件到 MessageStore |
+| `/api/callback/task-session/create` | POST | 创建任务子会话 |
+| `/api/callback/task-session/finish` | POST | 完成任务会话 |
+| `/api/callback/incident` | POST | 创建经济事件 |
+| `/api/callback/session/title` | POST | 更新会话标题 |
+| `/api/callback/invocation/complete` | POST | 标记调用完成 |
+
+### 2.2 服务层
+
+#### QueueController
+- 每个 Agent 一个 FIFO 队列（`asyncio.Queue`，max_depth=10）
+- 串行调度：一个 Agent 同时只处理一个 invocation
+- `enqueue()` → `_process_loop()` → `dispatch_fn()`
+
+#### EventRouter
+- 每个连接的 Agent 维护一个 `asyncio.Queue`
+- Agent 通过 SSE 长连接接收事件
+- 支持精确路由（`agent:xxx`）和广播（`*`）
+
+#### ProcessManager
+- 通过 `asyncio.create_subprocess_exec` 启动 Agent 子进程
+- 环境变量传递配置：`SIMU_SERVER_URL`, `SIMU_AGENT_ID`, `SIMU_AGENT_TOKEN`, `SIMU_CONFIG_PATH`
+- 支持优雅关闭（SIGTERM + 30s timeout）
+
+#### InvocationManager
+- 追踪每次 Agent 调用的生命周期：QUEUED → RUNNING → SUCCEEDED/FAILED
+- SQLite 持久化
+
+#### SessionManager
+- 会话 CRUD（SQLite）
+- 支持父子会话关系（task session 嵌套）
+- 元数据存储（标题、Agent 列表、状态）
+
+#### MessageStore
+- 消息持久化（SQLite + JSONL 双写）
+- 为前端提供会话消息历史
+
+### 2.3 游戏引擎
+
+#### GameState
+- 内存中维护 `NationData`（国库、税率、省份数据）
+- 省份字段：`production_value`, `population`, `fixed_expenditure`, `stockpile`, `tax_modifier`, `base_production_growth`, `base_population_growth`
+- 国家字段：`imperial_treasury`, `base_tax_rate`, `tribute_rate`, `fixed_expenditure`
+
+#### TickCoordinator
+- 手动触发（`POST /api/state/tick`）
+- 流程：应用增长率 → 应用 Incident 效果 → 计算税收/国库 → 刷新 Incident
+
+#### IncidentSystem
+- 管理有时限的经济事件
+- Effect 类型：`add`（一次性加减）/ `factor`（每 tick 乘性变化）
+- `tax_modifier` 等修正字段允许为零或负值
+
+### 2.4 经济公式
+
+```
+省级税收 = production_value × (base_tax_rate + tax_modifier)
+省级结余 = 省级税收 - fixed_expenditure
+省级上缴 = max(0, 省级结余 × tribute_rate)
+省级库存 += max(0, 省级结余 - 省级上缴)
+国库 += sum(各省上缴) - 国家 fixed_expenditure
+```
+
+---
+
+## 3. Agent SDK 模块
+
+### 3.1 BaseAgent 生命周期
+
+```
+__init__() → 初始化 ServerClient, SessionStateManager, LLM, Tape, Memory, Tools
+start()    → tape.initialize() → server.register() → _event_loop() + _heartbeat_loop()
+on_event() → 事件分发（SHUTDOWN / TASK_FINISHED / AGENT_MESSAGE / CHAT 等）
+react()    → ReActLoop.run() → RESPONSE → push_tape_event → post_message
+stop()     → server.deregister() → cleanup
+```
+
+### 3.2 事件分发逻辑 (`on_event`)
+
+```python
+if SHUTDOWN:        stop()
+if RELOAD_CONFIG:   reload personality
+if TASK_FINISHED/FAILED:
+    _handle_task_completion()  # unblock parent, react, drain queue
+if AGENT_MESSAGE/RESPONSE:
+    if clears pending reply:
+        if fully unblocked: react() + drain queue
+        else: enqueue for later
+    # falls through if not a reply
+if session blocked: enqueue
+else: react(event)
+```
+
+### 3.3 ReAct 循环
+
+```
+while iterations < max_iterations:
+  1. LLM(system_prompt + context + event)
+  2. if tool_calls:
+       execute each tool, record to tape
+       if any tool returns ends_loop=True → return
+  3. else:
+       return text as final response
+```
+
+- 最大迭代次数：10（默认）
+- 最大工具调用次数：20（默认）
+- 支持 Anthropic 和 OpenAI 消息格式
+
+### 3.4 系统提示构建
+
+`_build_system_prompt(session_id)` 按顺序拼接：
+1. `soul.md` — 角色性格
+2. `data_scope.yaml` — 数据权限范围
+3. 行动执行指令 — 何时使用 `create_incident`（仅有 `data_scope` 的 agent）
+4. 任务派发指令 / 任务执行指令 — 根据会话类型
+5. 消息回复指令 — 区分 send_message 与直接文字回复
+
+### 3.5 SessionStateManager
+
+每个 Agent 内部维护的会话状态：
+
+| 状态 | 说明 |
 |------|------|
-| **上层依赖下层** | Adapter → Application → Core |
-| **Core 无依赖** | Core 层不依赖上层 |
-| **无循环依赖** | 严格避免循环依赖 |
-| **依赖注入** | 通过 ApplicationServices 容器管理 |
+| `pending_tasks` | 未完成的 task sub-session ID 集合 |
+| `pending_replies` | 等待回复的消息 ID → 发送者映射 |
+| `message_queue` | 被阻塞时的事件队列 |
+| `session hierarchy` | parent/child 关系，嵌套深度（最大 5 层） |
+| `active_session` | 当前 ReAct 循环目标会话 |
+
+**阻塞语义**：当 session 有 pending tasks 或 pending replies 时，新事件被入队而非立即处理。
+
+### 3.6 标准工具
+
+| 工具 | 类别 | 关键行为 |
+|------|------|---------|
+| `send_message` | communication | `await_reply=true` 阻塞会话等待回复 |
+| `query_state` | communication | 查询游戏状态（path 参数支持点号导航） |
+| `query_role_map` | communication | 返回所有官员的名称、agent_id、职责 |
+| `create_incident` | action | 创建经济效果，Server 校验权限和数值 |
+| `create_task_session` | session | 返回 `ends_loop=True`，切换到子会话 |
+| `finish_task_session` | session | 返回 `ends_loop=True`，切回父会话 |
+| `fail_task_session` | session | 同上，标记失败 |
+| `search_memory` | memory | ChromaDB 向量检索历史会话 |
+
+### 3.7 Tape 与 Memory 系统
+
+**TapeManager**：
+- 每个 agent、每个 session 独立的 JSONL 文件
+- SQLite 索引用于查询
+- 可选 mirror 到 `data/memory/` 共享目录
+
+**ContextManager**：
+- 滑动窗口：保留最近事件，压缩旧事件为 ViewSegment
+- 会话摘要：每次 response 后由 LLM 更新
+- ViewSegment 存入 ChromaDB 供跨会话检索
+
+**MemoryRetriever**（两级搜索）：
+- L1：跨会话搜索（session 标题/摘要匹配）
+- L2：会话内搜索（ViewSegment 内容匹配）
 
 ---
 
-## 2. EventBus 模块
+## 4. 前端
 
-### 2.1 模块结构
+**技术栈**：React 18 + Vite + TypeScript + Tailwind CSS
 
-```
-src/simu_emperor/event_bus/
-├── event.py          # Event 数据模型
-├── core.py           # EventBus 核心实现
-├── logger.py         # 事件日志记录器
-└── event_types.py    # 事件类型常量
-```
+**主要功能**：
+- WebSocket 实时接收事件
+- 会话列表和切换
+- 聊天界面（发送指令，显示 Agent 回复）
+- 游戏状态面板（省份数据、国库、Incident 列表）
 
-### 2.2 Event 数据模型
-
-```python
-@dataclass
-class Event:
-    event_id: str            # evt_YYYYMMDDHHMMSS_uuid8
-    src: str                 # 事件源（如 "player", "agent:revenue_minister"）
-    dst: list[str]           # 目标列表（支持多个接收者）
-    type: str                # 事件类型（CHAT, RESPONSE, TICK_COMPLETED 等）
-    payload: dict            # 事件负载数据
-    timestamp: str           # UTC 时间戳
-    session_id: str          # 会话 ID（必填）
-    parent_event_id: str     # 父事件 ID（事件链追踪）
-    root_event_id: str       # 根事件 ID（自动计算）
-```
-
-### 2.3 事件路由规则
-
-EventBus 支持三种路由模式，优先级从高到低：
-
-1. **精确匹配**：`dst` 直接匹配订阅者
-2. **前缀匹配**：`agent:*` 匹配所有 Agent
-3. **广播匹配**：`*` 匹配所有订阅者
-
-```python
-# 订阅示例
-event_bus.subscribe("agent:revenue_minister", handler)  # 精确
-event_bus.subscribe("agent:*", handler)                 # 前缀
-event_bus.subscribe("*", handler)                       # 广播
-```
-
-### 2.4 事件类型
-
-| 分类 | 事件类型 | 说明 |
-|------|----------|------|
-| 玩家交互 | `CHAT` | 玩家命令/聊天 |
-| Agent 响应 | `RESPONSE` | Agent 回复玩家 |
-| Agent 通信 | `AGENT_MESSAGE` | Agent 间消息 |
-| 系统事件 | `TICK_COMPLETED` | Tick 完成 |
-| 系统事件 | `INCIDENT_CREATED` | 游戏事件创建 |
-| 任务事件 | `TASK_CREATED` | 任务会话创建 |
-| 任务事件 | `TASK_FINISHED` | 任务完成 |
+**WebSocket 消息类型**：
+- `chat`: Agent 消息
+- `state`: 游戏状态更新
+- `event`: TapeEvent
+- `session_state`: 会话状态变更
+- `task_finished`: 任务完成通知
 
 ---
 
-## 3. Engine 模块
+## 5. 核心数据流
 
-### 3.1 模块结构
-
-```
-src/simu_emperor/engine/
-├── models/
-│   ├── base_data.py     # NationData, ProvinceData
-│   └── incident.py      # Incident, Effect
-├── engine.py            # Engine 核心类
-├── tick_coordinator.py  # Tick 定时器
-└── protocols.py         # Repository 协议
-```
-
-### 3.2 数据模型
-
-#### ProvinceData（省级数据）
-
-```python
-@dataclass
-class ProvinceData:
-    province_id: str
-    name: str
-
-    # 四个核心字段（V4 简化）
-    production_value: Decimal    # 产值
-    population: Decimal          # 人口
-    fixed_expenditure: Decimal   # 固定支出
-    stockpile: Decimal           # 库存
-
-    # 增长率（固定）
-    base_production_growth: Decimal = 0.01   # 1%/tick
-    base_population_growth: Decimal = 0.005  # 0.5%/tick
-
-    # 税率修正
-    tax_modifier: Decimal = 0.0
-```
-
-#### NationData（国家数据）
-
-```python
-@dataclass
-class NationData:
-    turn: int                           # 当前 tick 数
-    base_tax_rate: Decimal = 0.10       # 基础税率 10%
-    tribute_rate: Decimal = 0.8         # 上缴比例 80%
-    fixed_expenditure: Decimal = 0      # 国库固定支出
-    imperial_treasury: Decimal = 0      # 国库
-    provinces: Dict[str, ProvinceData]   # 省份数据
-```
-
-#### Incident/Effect（游戏事件）
-
-```python
-@dataclass
-class Effect:
-    target_path: str        # "provinces.zhili.production_value"
-    add: Decimal            # 一次性变化（与 factor 二选一）
-    factor: Decimal          # 持续比例（与 add 二选一）
-
-@dataclass
-class Incident:
-    incident_id: str
-    title: str
-    description: str
-    effects: List[Effect]
-    source: str
-    remaining_ticks: int    # 持续 tick 数
-    applied: bool = False   # add 效果是否已生效
-```
-
-### 3.3 Tick 计算流程
+### 5.1 玩家指令 → Agent 执行
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    Engine.apply_tick()                      │
-├─────────────────────────────────────────────────────────────┤
-│  1. _save_previous_values()    # 保存当前状态用于计算 delta │
-│  2. _apply_base_growth()       # 应用基础增长率             │
-│  3. _apply_effects()           # 应用所有活跃 Effect        │
-│  4. _calculate_tax_and_treasury()  # 税收和国库结算        │
-│  5. _refresh_incidents()       # 刷新 Incident 状态         │
-│  6. state.turn += 1            # 增加 tick 计数            │
-└─────────────────────────────────────────────────────────────┘
+1. Frontend: POST /api/command {text, session_id, agent?}
+2. Server client.py:
+   - 创建 TapeEvent(src=player, type=CHAT, dst=[agent:xxx])
+   - 存入 MessageStore
+   - QueueController.enqueue(agent_id, event)
+3. QueueController:
+   - dispatch_fn(agent_id, event)
+   - InvocationManager.create() → mark_running()
+   - EventRouter.route(event) → agent 的 SSE 队列
+4. Agent (via SSE):
+   - ServerClient.event_stream() 接收 TapeEvent
+   - on_event() → react(event)
+5. ReActLoop:
+   - LLM 读取 system_prompt + context + event
+   - 决定调用工具或直接回复
+   - 工具执行（query_state, create_incident 等）
+6. Agent 发送 RESPONSE:
+   - push_tape_event(response, route=should_route)
+   - post_message(recipients=["player"], message=content)
+7. Server:
+   - 存入 MessageStore
+   - WebSocket broadcast → Frontend 显示
 ```
 
-### 3.4 经济公式
+### 5.2 Agent 间通信
 
-**省级税收**：
 ```
-province_tax = production_value × (base_tax_rate + tax_modifier)
-```
-
-**省级结余**：
-```
-province_surplus = province_tax - fixed_expenditure
-```
-
-**省级上缴**：
-```
-province_remittance = max(0, province_surplus × tribute_rate)
+1. Agent A 调用 send_message(recipients=["agent_b"], await_reply=true)
+2. ServerClient POST /api/callback/message
+3. Server 创建 TapeEvent(src=agent:A, type=AGENT_MESSAGE)
+4. QueueController.enqueue("agent_b", event) → EventRouter → Agent B SSE
+5. Agent B: on_event() → react(event) → 输出文字回复
+6. 文字输出包装为 RESPONSE event，push_tape_event(route=True)
+7. Server callback.py: 检测 route=True + type=RESPONSE → enqueue 给 Agent A
+8. Agent A: on_event() → _try_clear_pending_reply() → 成功
+9. Session 解除阻塞 → react(reply_event) → 处理回复
 ```
 
-**省级库存**：
+### 5.3 Task Session 流程
+
 ```
-stockpile = max(0, province_surplus - province_remittance)
-```
-
-**国库更新**：
-```
-imperial_treasury = max(0, imperial_treasury + sum(上缴) - fixed_expenditure)
-```
-
-### 3.5 TickCoordinator
-
-定时触发 tick 的协调器，默认每 5 秒执行一次：
-
-```python
-class TickCoordinator:
-    async def _tick_loop(self):
-        while self._running:
-            # 1. 执行 tick
-            new_state = self.engine.apply_tick()
-
-            # 2. 持久化状态
-            await self._persist_state(new_state)
-
-            # 3. 广播事件
-            await self.event_bus.send_event(Event(
-                type="tick_completed",
-                dst=["*"],
-                payload={"tick": new_state.turn}
-            ))
-
-            # 4. 等待固定间隔
-            await asyncio.sleep(tick_interval)
+1. 玩家: "问问张廷玉身体如何" → Agent A (governor)
+2. Agent A react():
+   - query_role_map() → 找到 minister_of_revenue
+   - create_task_session(goal="询问张廷玉身体状况")
+     → ends_loop=True, 父 session 标记为 blocked
+3. Agent A 进入 task session:
+   - 收到 TASK_CREATED 合成事件
+   - send_message(recipients=["minister_of_revenue"], await_reply=true)
+     → ends_loop=True, task session 等待回复
+4. Agent B (minister) 收到消息 → react → 文字回复
+5. RESPONSE 路由回 Agent A (task session)
+6. Agent A task session 解除阻塞 → react(reply):
+   - finish_task_session(result="张廷玉说...")
+     → ends_loop=True
+7. Server: finish_task_session → TASK_FINISHED event → enqueue 给 Agent A (parent session)
+8. Agent A parent session: _handle_task_completion() → react(TASK_FINISHED)
+   - 向 player 汇报结果
 ```
 
 ---
 
-## 4. Agents 模块
+## 6. 事件类型
 
-### 4.1 模块结构
+| 类型 | 方向 | 说明 |
+|------|------|------|
+| `CHAT` | player → agent | 玩家指令 |
+| `AGENT_MESSAGE` | agent → agent | 主动发起的消息 |
+| `RESPONSE` | agent → agent/player | 自动路由的回复 |
+| `TASK_CREATED` | agent → self | 进入任务会话的合成事件 |
+| `TASK_FINISHED` | server → agent | 任务完成（路由到父会话） |
+| `TASK_FAILED` | server → agent | 任务失败 |
+| `TOOL_CALL` | agent → tape | 工具调用记录 |
+| `TOOL_RESULT` | agent → tape | 工具结果记录 |
+| `SHUTDOWN` | server → agent | 优雅关闭 |
+| `RELOAD_CONFIG` | server → agent | 热重载配置 |
 
-```
-src/simu_emperor/agents/
-├── agent.py              # Agent 基类
-├── manager.py            # Agent 生命周期管理
-├── agent_generator.py    # LLM 动态生成 Agent
-├── skills/               # Skill 文件系统
-│   ├── models.py         # Skill 数据模型
-│   ├── parser.py         # YAML Frontmatter 解析
-│   ├── loader.py         # 三级缓存加载器
-│   ├── registry.py       # 事件到技能映射
-│   └── validator.py      # Skill 校验
-├── tools/                # Function Calling 工具
-│   ├── query_tools.py    # 查询工具（返回数据）
-│   ├── action_tools.py   # 行动工具（执行副作用）
-│   └── memory_tools.py   # 记忆工具
-└── response_parser.py    # LLM 响应解析
-```
-
-### 4.2 Agent 设计
-
-**核心原则**：
-- **被动 Agent**：只响应事件，不主动发起
-- **文件驱动**：soul.md 定义性格，data_scope.yaml 定义权限
-- **Function Calling**：LLM 自主决定调用哪些工具
-
-**Agent 生命周期**：
-```
-初始化 → 订阅事件 → 接收事件 → 构建上下文 → LLM 调用 → 执行工具 → 响应
-```
-
-### 4.3 Skill 系统（v2.0）
-
-**三级缓存架构**：
-```
-L1: 内存缓存（LRU，最多 50 项）
-  ↓ (miss)
-L2: mtime 缓存（文件修改时间检测）
-  ↓ (changed)
-L3: 文件系统（通过 SkillParser 加载）
-```
-
-**Skill 文件格式**：
-```markdown
----
-name: query_data
-description: 查询职权范围内的数据
-version: "2.0"
-priority: 20
-required_tools:
-  - query_national_data
-  - query_province_data
 ---
 
-# 查阅数据
+## 7. Agent 配置
 
-## 任务说明
-你可以查阅你职权范围内的数据...
+### 7.1 soul.md 示例
 
-## 执行流程
-1. 理解查询需求
-2. 查询数据
-3. 分析数据
-4. 回复皇帝
-```
-
-**事件到技能映射**：
-```python
-DEFAULT_EVENT_SKILL_MAP = {
-    EventType.CHAT: "chat",
-    EventType.AGENT_MESSAGE: "receive_message",
-    EventType.TICK_COMPLETED: "on_tick_completed",
-}
-```
-
-### 4.4 Tool 系统
-
-| 工具类型 | 函数名 | 功能 |
-|----------|--------|------|
-| Query | `query_national_data` | 查询国家级数据 |
-| Query | `query_province_data` | 查询省份数据 |
-| Query | `list_provinces` | 列出可用省份 |
-| Query | `list_agents` | 列出所有官员 |
-| Query | `retrieve_memory` | 检索历史记忆 |
-| Action | `respond_to_player` | 回复皇帝 |
-| Action | `send_message_to_agent` | 发消息给其他 Agent |
-| Action | `create_incident` | 创建游戏事件 |
-
-### 4.5 文件驱动的 Agent 定义
-
-**soul.md 示例**：
 ```markdown
 # 户部尚书 - 张廷玉
 
@@ -363,474 +401,55 @@ DEFAULT_EVENT_SKILL_MAP = {
 文言与白话混用，言辞恭敬但暗含城府。
 ```
 
-**data_scope.yaml 示例**：
+### 7.2 data_scope.yaml 示例
+
 ```yaml
 display_name: 户部尚书
 
-skills:
-  query_data:
-    provinces: [zhili, jiangnan]
-    fields:
-      - population.*
-      - agriculture.*
-
-  execute_command:
-    provinces: [zhili]
-    fields:
-      - taxation.land_tax_rate
+provinces: all
+fields:
+  - production_value
+  - population
+  - stockpile
+  - tax_modifier
+nation_fields:
+  - imperial_treasury
+  - base_tax_rate
+  - tribute_rate
+  - fixed_expenditure
 ```
 
----
-
-## 5. Memory 模块
-
-### 5.1 模块结构
-
-```
-src/simu_emperor/memory/
-├── tape_writer.py         # 事件写入 tape.jsonl
-├── tape_metadata.py       # 元数据管理
-├── context_manager.py     # 滑动窗口上下文
-├── manifest_index.py      # 会话索引
-└── ...
-```
-
-### 5.2 Tape 文件结构
-
-```
-data/memory/
-├── tape_meta.jsonl              # 全局元数据索引
-├── session_manifest.json        # Session 状态管理
-└── agents/
-    └── {agent_id}/
-        └── sessions/
-            └── {session_id}/
-                ├── tape.jsonl    # 事件日志
-                └── tape_meta.jsonl # 会话元数据
-```
-
-### 5.3 ContextManager - 滑动窗口
-
-**配置参数**：
-```python
-ContextConfig:
-    max_tokens: 8000              # LLM 上下文窗口
-    threshold_ratio: 0.95         # 触发压缩阈值（95%）
-    keep_recent_events: 20        # 保留的最小事件数
-    anchor_buffer: 3              # 锚点附近保留事件数
-    enable_anchor_aware: True     # 启用锚点感知
-```
-
-**锚点事件**：
-- 用户查询（USER_QUERY）
-- Agent 响应（RESPONSE, ASSISTANT_RESPONSE）
-- 关键游戏状态（GAME_EVENT）
-
-**滑动窗口压缩策略**：
-1. 识别锚点位置
-2. 总是保留最近 N 个事件
-3. 额外保留锚点附近 ±K 个事件
-4. 如果 token 仍超阈值，继续删除最旧事件
-5. 更新 segment_index 和累积摘要
-
-### 5.4 Session 管理
-
-**会话类型**：
-- 主会话：`session:web:{timestamp}:{suffix}`
-- 任务会话：`task:{agent_name}:{timestamp}:{suffix}`
-
-**会话嵌套**：
-- 最大嵌套深度：5 层
-- 父子关系：parent_id ↔ child_ids
-- 祖先链：get_parent_chain()
-
-**Agent 状态**：
-- `ACTIVE`：正常处理
-- `WAITING_REPLY`：等待异步回复
-- `FINISHED`：已完成
-- `FAILED`：失败
-
----
-
-## 6. Application 层
-
-### 6.1 模块结构
-
-```
-src/simu_emperor/application/
-├── services.py            # ApplicationServices 容器
-├── game_service.py        # 游戏生命周期
-├── session_service.py     # 会话管理
-├── agent_service.py       # Agent 生命周期
-├── group_chat_service.py  # 群聊功能
-├── message_service.py     # 消息路由
-└── tape_service.py        # Tape 查询
-```
-
-### 6.2 ApplicationServices 容器
-
-**依赖注入容器**，按顺序初始化：
-```
-1. LLM Provider
-2. Database + Repository
-3. EventBus + Logger
-4. Memory Components
-5. SessionManager
-6. GameService
-7. AgentService
-8. SessionService
-9. GroupChatService
-10. MessageService
-11. TapeService
-```
-
-### 6.3 服务职责
-
-| 服务 | 职责 |
-|------|------|
-| GameService | 游戏状态初始化、tick 协调、状态查询 |
-| SessionService | 会话创建/选择、标题管理、Agent 绑定 |
-| AgentService | Agent 初始化、动态生成、可用性查询 |
-| GroupChatService | 群聊创建、成员管理、消息广播 |
-| MessageService | 命令/聊天发送、广播、消息解析 |
-| TapeService | Tape 查询、子会话支持、事件检索 |
-
----
-
-## 7. Web Adapter 模块
-
-### 7.1 模块结构
-
-```
-src/simu_emperor/adapters/web/
-├── server.py              # FastAPI 服务器
-├── connection_manager.py  # WebSocket 连接管理
-├── game_instance.py       # 游戏实例包装
-└── message_converter.py   # 消息格式转换
-```
-
-### 7.2 REST API 端点
-
-| 端点 | 方法 | 功能 |
-|------|------|------|
-| `/ws` | WebSocket | 实时通信 |
-| `/api/command` | POST | 发送命令 |
-| `/api/state` | GET | 获取游戏状态 |
-| `/api/overview` | GET | 获取帝国概况 |
-| `/api/sessions` | GET/POST | 会话管理 |
-| `/api/tape/current` | GET | 获取事件记录 |
-| `/api/agents` | GET/POST | Agent 管理 |
-| `/api/groups` | GET/POST | 群聊管理 |
-| `/api/health` | GET | 健康检查 |
-
-### 7.3 WebSocket 消息格式
-
-**客户端 → 服务器**：
-```json
-{
-    "type": "command" | "chat",
-    "agent": "governor_zhili",
-    "text": "查看直隶省情况",
-    "session_id": "session:web:..."
-}
-```
-
-**服务器 → 客户端**：
-```json
-{
-    "kind": "chat" | "state" | "event" | "error",
-    "data": {
-        "agent": "governor_zhili",
-        "text": "回复内容",
-        "timestamp": "2026-03-15T12:00:00Z"
-    }
-}
-```
-
----
-
-## 8. LLM 模块
-
-### 8.1 模块结构
-
-```
-src/simu_emperor/llm/
-├── base.py          # LLMProvider 接口
-├── anthropic.py     # Claude 实现
-├── openai.py        # GPT 实现
-└── mock.py          # 测试提供商
-```
-
-### 8.2 LLMProvider 接口
-
-```python
-class LLMProvider(ABC):
-    async def call(
-        prompt: str,
-        system_prompt: str = None,
-        temperature: float = 0.7,
-        max_tokens: int = 2000,
-    ) -> str
-
-    async def call_with_functions(
-        prompt: str,
-        functions: list[dict],
-        system_prompt: str = None,
-        temperature: float = 0.7,
-        max_tokens: int = 2000,
-    ) -> dict  # {response_text, tool_calls}
-
-    def get_context_window_size() -> int
-```
-
-### 8.3 Function Calling 支持
-
-统一函数定义格式：
-```python
-{
-    "name": "query_province_data",
-    "description": "查询省份数据",
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "province_id": {"type": "string"},
-            "field_path": {"type": "string"}
-        },
-        "required": ["province_id", "field_path"]
-    }
-}
-```
-
----
-
-## 9. 数据持久化
-
-### 9.1 模块结构
-
-```
-src/simu_emperor/persistence/
-├── database.py       # SQLite 连接管理
-├── repositories.py   # Repository 模式 CRUD
-└── serialization.py  # 状态序列化
-```
-
-### 9.2 数据库表
-
-**game_state**：
-```sql
-CREATE TABLE game_state (
-    id INTEGER PRIMARY KEY,
-    state_json TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
-```
-
-**agent_state**：
-```sql
-CREATE TABLE agent_state (
-    agent_id TEXT PRIMARY KEY,
-    is_active INTEGER NOT NULL,
-    soul_markdown TEXT,
-    data_scope_yaml TEXT,
-    updated_at TEXT NOT NULL
-);
-```
-
-**events**：
-```sql
-CREATE TABLE events (
-    event_id TEXT PRIMARY KEY,
-    session_id TEXT NOT NULL,
-    src TEXT NOT NULL,
-    dst TEXT NOT NULL,
-    type TEXT NOT NULL,
-    payload TEXT NOT NULL,
-    timestamp TEXT NOT NULL
-);
-```
-
----
-
-## 10. 配置管理
-
-### 10.1 配置文件
-
-**config.yaml**（可选）：
-```yaml
-llm:
-  provider: anthropic
-  model: claude-sonnet-4-20250514
-  context_window: 200000
-
-memory:
-  enabled: true
-  context:
-    max_tokens: 8000
-    threshold_ratio: 0.95
-    keep_recent_events: 20
-  retrieval:
-    cross_session_enabled: true
-```
-
-### 10.2 环境变量
-
-```bash
-# LLM 配置
-ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_API_KEY=sk-...
-SIMU_LLM__PROVIDER=anthropic
-
-# 游戏配置
-SIMU_DB_PATH=game.db
-SIMU_DATA_DIR=data
-SIMU_LOG_DIR=data/logs
-
-# 日志配置
-SIMU_LOGGING__LOG_LEVEL=INFO
-SIMU_LOGGING__LLM_AUDIT_ENABLED=true
-```
-
----
-
-## 11. 关键设计模式
-
-### 11.1 事件驱动
-
-所有模块通过 EventBus 通信，无直接函数调用：
-```
-Player → Event → EventBus → Agent → Event → EventBus → Player
-```
-
-### 11.2 Repository 模式
-
-数据访问通过 Repository 抽象：
-```
-Application → Repository → Database
-```
-
-### 11.3 依赖注入
-
-通过 ApplicationServices 容器管理依赖：
-```
-ApplicationServices.create() → 所有服务初始化
-```
-
-### 11.4 文件驱动
-
-Agent 配置通过文件定义，无需修改代码：
-```
-soul.md + data_scope.yaml → Agent 行为
-```
-
----
-
-## 12. 数据流
-
-### 12.1 玩家命令流
-
-```
-1. 玩家输入 → WebSocket/REST
-2. Web Adapter → MessageService.send_command()
-3. MessageService → EventBus (CHAT event)
-4. EventBus → Agent (订阅者)
-5. Agent → TapeWriter.write_event() (写入 tape.jsonl)
-6. Agent → ContextManager (构建上下文)
-7. Agent → LLM.call_with_functions()
-8. LLM → Agent (tool_calls)
-9. Agent → ActionTools/QueryTools (执行工具)
-10. Agent → respond_to_player()
-11. EventBus → Web Adapter (RESPONSE event)
-12. WebSocket → 玩家
-```
-
-### 12.2 Tick 流
-
-```
-1. TickCoordinator._tick_loop() 触发
-2. Engine.apply_tick()
-3. 状态持久化
-4. EventBus.send_event(TICK_COMPLETED)
-5. 所有 Agent 接收事件
-6. Agent 执行 tick 响应逻辑
-```
-
----
-
-## 13. 扩展指南
-
-### 13.1 添加新 Agent
+### 7.3 添加新 Agent
 
 1. 创建 `data/default_agents/{agent_id}/` 目录
 2. 编写 `soul.md`（性格定义）
 3. 编写 `data_scope.yaml`（权限定义）
-4. 重启服务自动加载
-
-### 13.2 添加新 Skill
-
-1. 创建 `data/skills/{skill_name}.md`
-2. 定义 YAML Frontmatter（元数据）
-3. 编写 Markdown Body（任务说明）
-4. 更新 registry.py 映射
-
-### 13.3 添加新 Tool
-
-1. 在 `tools/query_tools.py` 或 `tools/action_tools.py` 添加函数
-2. 在 `tool_definitions.py` 注册定义
-3. 在 Agent 中注册处理器
+4. Server 启动时自动加载并注册
 
 ---
 
-## 14. 模块详细文档
+## 8. 已知限制与风险
 
-本文档提供系统架构的总体概览。各模块的详细架构图和运行流程请参考对应的 AGENTS.md 文档：
+### 8.1 并发风险
 
-### 核心层模块
+- QueueController `enqueue()` 存在 TOCTOU 竞态（应原子化状态检查）
+- EventRouter/WSManager 遍历中可能被并发修改
+- GameState 读写无锁保护（tick 和 query_state 可能并发）
+- SessionManager 的 read-modify-write 模式可能丢失更新
 
-| 模块 | 文档路径 | 内容 |
-|------|----------|------|
-| **EventBus** | [`src/simu_emperor/event_bus/AGENTS.md`](../../src/simu_emperor/event_bus/AGENTS.md) | 事件路由规则、异步处理机制、事件链追踪 |
-| **Engine** | [`src/simu_emperor/engine/AGENTS.md`](../../src/simu_emperor/engine/AGENTS.md) | Tick 计算流程、Incident/Effect 系统、经济公式 |
-| **Agents** | [`src/simu_emperor/agents/AGENTS.md`](../../src/simu_emperor/agents/AGENTS.md) | Agent 生命周期、Skill 系统、Tool 调用、三级缓存 |
-| **Memory** | [`src/simu_emperor/memory/AGENTS.md`](../../src/simu_emperor/memory/AGENTS.md) | Tape 写入、滑动窗口、累积摘要、跨会话检索 |
+### 8.2 性能瓶颈
 
-### 应用层模块
+- Server 为单进程 asyncio，所有 Agent 的 IO 集中于此
+- SQLite 写操作互斥
+- LLM 调用延迟（3-30 秒）是主要时间开销
+- `_update_session_summary` 的 LLM 调用曾阻塞事件循环（已改为异步后台执行）
 
-| 模块 | 文档路径 | 内容 |
-|------|----------|------|
-| **Application** | [`src/simu_emperor/application/AGENTS.md`](../../src/simu_emperor/application/AGENTS.md) | 服务容器、依赖注入、消息路由、会话管理 |
-| **Session** | [`src/simu_emperor/session/AGENTS.md`](../../src/simu_emperor/session/AGENTS.md) | 会话嵌套、Per-Agent 状态、异步回复计数 |
+### 8.3 扩展方向
 
-### 适配器层模块
-
-| 模块 | 文档路径 | 内容 |
-|------|----------|------|
-| **Web Adapter** | [`src/simu_emperor/adapters/web/AGENTS.md`](../../src/simu_emperor/adapters/web/AGENTS.md) | WebSocket 连接、REST API、消息转换 |
-
-### 基础设施模块
-
-| 模块 | 文档路径 | 内容 |
-|------|----------|------|
-| **LLM** | [`src/simu_emperor/llm/AGENTS.md`](../../src/simu_emperor/llm/AGENTS.md) | LLMProvider 接口、Function Calling、多提供商支持 |
-| **Persistence** | [`src/simu_emperor/persistence/AGENTS.md`](../../src/simu_emperor/persistence/AGENTS.md) | Repository 模式、数据库表结构、Decimal 序列化 |
-
-### 文档内容概览
-
-每个 AGENTS.md 文档包含：
-
-1. **架构示意图**（Mermaid 图表）
-   - 模块组件关系
-   - 数据模型结构
-   - 与其他模块的接口
-
-2. **详细运行流程**（Mermaid 图表）
-   - 完整的处理流程
-   - 决策分支和条件
-   - 时序交互关系
-
-3. **开发约束**
-   - 架构约束规则
-   - 错误处理规范
-   - 性能考虑事项
+参见 `docs/research/v6-architecture-research.md`：
+- MCP 协议化工具
+- 核心服务从 Python/SQLite 迁移到 Go/Rust + PostgreSQL
+- EventRouter 用 Redis Stream 或 NATS 替代
 
 ---
 
@@ -842,13 +461,27 @@ soul.md + data_scope.yaml → Agent 行为
 - 4 ticks = 1 月
 - 48 ticks = 1 年
 
-### B. Agent ID 规范
+### B. ID 规范
 
-- 格式：`{role}_{province}` 或 `{role}`
-- 示例：`governor_zhili`, `minister_of_revenue`
-- 前缀：`agent:{agent_id}`
+- Agent ID: `{role}_{province}` 或 `{role}`（如 `governor_zhili`, `minister_of_revenue`）
+- Agent 前缀: `agent:{agent_id}`
+- 主会话: `session:web:{suffix}`
+- 任务会话: `task:{suffix}`
 
-### C. Session ID 规范
+### C. 环境变量
 
-- 主会话：`session:web:{agent_id}:{timestamp}:{suffix}`
-- 任务会话：`task:{agent_name}:{timestamp}:{suffix}`
+```bash
+# Agent 进程配置（由 ProcessManager 设置）
+SIMU_SERVER_URL=http://localhost:8000
+SIMU_AGENT_ID=governor_zhili
+SIMU_AGENT_TOKEN=<hex token>
+SIMU_CONFIG_PATH=data/agents/governor_zhili
+
+# LLM 配置
+SIMU_LLM_PROVIDER=anthropic
+SIMU_LLM_MODEL=claude-sonnet-4-20250514
+ANTHROPIC_API_KEY=sk-ant-...
+
+# 可选
+SIMU_MEMORY_DIR=data/memory  # 启用 tape mirror
+```


### PR DESCRIPTION
## Summary
- Rewrote `CLAUDE.md` to reflect the current V5 process-per-agent architecture, replacing the outdated V4.2 EventBus-based description
- Rewrote `docs/architecture/ARCHITECTURE.md` with V5 system diagram, server/SDK module breakdown, data flows, event types, agent configuration, and known concurrency risks
- Both files now accurately describe the 4-package uv workspace (shared, sdk, server, agents), SSE + HTTP callback communication, ReAct loop, session state management, and memory system

## Test plan
- [ ] Review CLAUDE.md for accuracy against current codebase
- [ ] Review ARCHITECTURE.md diagrams and module descriptions
- [ ] Verify no stale V4 references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)