### PR TITLE
feat: MCP server layer + V5 bug fixes

### DIFF
--- a/packages/server/pyproject.toml
+++ b/packages/server/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0",
     "anthropic>=0.40",
     "openai>=1.50",
+    "mcp>=1.0",
 ]
 
 [project.scripts]

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -13,6 +13,8 @@ from simu_server.agents.generator import AgentGenerator
 from simu_server.agents.registry import AgentRegistry
 from simu_server.config import settings
 from simu_server.engine.game_engine import GameEngine
+from simu_server.mcp import set_role_dependencies, set_simu_dependencies, simu_mcp, role_mcp
+from simu_server.mcp.auth import MCPAuthMiddleware, set_process_manager
 from simu_server.routes import callback, client
 from simu_server.routes.client import WSManager, ws_manager, ws_router
 from simu_server.services.event_router import EventRouter
@@ -143,6 +145,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     client.set_dependencies(**deps)
     callback.set_dependencies(**deps)
 
+    # MCP server dependencies
+    set_process_manager(process_manager)
+    mcp_deps = {
+        "engine": engine,
+        "session_manager": session_manager,
+        "message_store": message_store,
+        "queue_controller": queue_controller,
+        "agent_registry": agent_registry,
+        "ws_manager": ws_manager,
+    }
+    set_simu_dependencies(**mcp_deps)
+    set_role_dependencies(agent_registry=agent_registry)
+
     # Spawn agent processes for all registered agents
     for agent in await agent_registry.list_all():
         if agent.config_path:
@@ -176,5 +191,9 @@ def create_app() -> FastAPI:
     app.include_router(client.router)
     app.include_router(ws_router)
     app.include_router(callback.router)
+
+    # Mount MCP servers with auth middleware
+    app.mount("/mcp/simu", MCPAuthMiddleware(simu_mcp.streamable_http_app()))
+    app.mount("/mcp/role", MCPAuthMiddleware(role_mcp.streamable_http_app()))
 
     return app

--- a/packages/server/simu_server/mcp/__init__.py
+++ b/packages/server/simu_server/mcp/__init__.py
@@ -1,0 +1,15 @@
+"""MCP Server Layer — simu-mcp and role-mcp services.
+
+Provides MCP (Model Context Protocol) interfaces for agent-server interaction,
+replacing the V5 HTTP callback pattern with standard MCP tool calls.
+"""
+
+from simu_server.mcp.simu_mcp import simu_mcp, set_dependencies as set_simu_dependencies
+from simu_server.mcp.role_mcp import role_mcp, set_dependencies as set_role_dependencies
+
+__all__ = [
+    "simu_mcp",
+    "role_mcp",
+    "set_simu_dependencies",
+    "set_role_dependencies",
+]

--- a/packages/server/simu_server/mcp/auth.py
+++ b/packages/server/simu_server/mcp/auth.py
@@ -63,14 +63,17 @@ class MCPAuthMiddleware:
             await self._send_error(send, 401, "Missing X-Agent-Id or X-Callback-Token header")
             return
 
-        if _process_manager is not None:
-            expected = _process_manager.get_token(agent_id)
-            if expected is None:
-                await self._send_error(send, 401, f"Unknown agent: {agent_id}")
-                return
-            if expected != token:
-                await self._send_error(send, 403, "Invalid callback token")
-                return
+        if _process_manager is None:
+            await self._send_error(send, 503, "Server not ready: ProcessManager not initialized")
+            return
+
+        expected = _process_manager.get_token(agent_id)
+        if expected is None:
+            await self._send_error(send, 401, f"Unknown agent: {agent_id}")
+            return
+        if expected != token:
+            await self._send_error(send, 403, "Invalid callback token")
+            return
 
         tok = current_agent_id.set(agent_id)
         try:

--- a/packages/server/simu_server/mcp/auth.py
+++ b/packages/server/simu_server/mcp/auth.py
@@ -1,0 +1,95 @@
+"""MCP authentication — token validation and agent identity context.
+
+Uses a raw ASGI middleware to validate X-Agent-Id / X-Callback-Token headers
+and set a contextvars.ContextVar so MCP tool functions can retrieve the
+authenticated agent ID without it being a tool parameter (preventing spoofing).
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Context variable holding the authenticated agent ID for the current request.
+current_agent_id: contextvars.ContextVar[str] = contextvars.ContextVar("current_agent_id")
+
+_process_manager: Any = None
+
+
+def set_process_manager(pm: Any) -> None:
+    """Store a reference to the ProcessManager for token validation."""
+    global _process_manager
+    _process_manager = pm
+
+
+def get_agent_id() -> str:
+    """Return the authenticated agent ID for the current request.
+
+    Raises RuntimeError if called outside an authenticated MCP request.
+    """
+    try:
+        return current_agent_id.get()
+    except LookupError:
+        raise RuntimeError("No authenticated agent in current context")
+
+
+class MCPAuthMiddleware:
+    """Raw ASGI middleware that wraps an MCP Starlette app.
+
+    Validates ``X-Agent-Id`` and ``X-Callback-Token`` headers before
+    forwarding the request to the inner app.  On success the
+    ``current_agent_id`` context variable is set so downstream MCP tool
+    handlers can call :func:`get_agent_id`.
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        # Extract headers (ASGI headers are list of (bytes, bytes) tuples)
+        headers: dict[bytes, bytes] = dict(scope.get("headers", []))
+        agent_id = headers.get(b"x-agent-id", b"").decode()
+        token = headers.get(b"x-callback-token", b"").decode()
+
+        if not agent_id or not token:
+            await self._send_error(send, 401, "Missing X-Agent-Id or X-Callback-Token header")
+            return
+
+        if _process_manager is not None:
+            expected = _process_manager.get_token(agent_id)
+            if expected is None:
+                await self._send_error(send, 401, f"Unknown agent: {agent_id}")
+                return
+            if expected != token:
+                await self._send_error(send, 403, "Invalid callback token")
+                return
+
+        tok = current_agent_id.set(agent_id)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            current_agent_id.reset(tok)
+
+    @staticmethod
+    async def _send_error(send: Any, status: int, detail: str) -> None:
+        body = json.dumps({"error": detail}).encode()
+        await send({
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": body,
+        })

--- a/packages/server/simu_server/mcp/role_mcp.py
+++ b/packages/server/simu_server/mcp/role_mcp.py
@@ -1,0 +1,110 @@
+"""role-mcp — Role and agent information MCP server.
+
+Exposes MCP tools for:
+- query_role_map: get the role assignment map
+- get_agents: list all registered agents and their status
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from simu_server.mcp.auth import get_agent_id
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dependency injection
+# ---------------------------------------------------------------------------
+
+_deps: dict[str, Any] = {}
+
+
+def set_dependencies(**kwargs: Any) -> None:
+    _deps.update(kwargs)
+
+
+def _get(name: str) -> Any:
+    v = _deps.get(name)
+    if v is None:
+        raise RuntimeError(f"MCP dependency not set: {name}")
+    return v
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server instance
+# ---------------------------------------------------------------------------
+
+role_mcp = FastMCP("role-mcp")
+
+
+# ---------------------------------------------------------------------------
+# Tool: query_role_map
+# ---------------------------------------------------------------------------
+
+@role_mcp.tool()
+async def query_role_map() -> str:
+    """Query the role assignment map.
+
+    Returns structured data about all official roles, including
+    title, agent_id, name, and duty for each role.
+    """
+    get_agent_id()  # ensure authenticated
+
+    from simu_server.config import settings
+
+    role_map_path = settings.data_dir / "role_map.md"
+    if not role_map_path.exists():
+        return json.dumps({"roles": []})
+
+    text = role_map_path.read_text(encoding="utf-8")
+    roles: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("## "):
+            if current:
+                roles.append(current)
+            title_part = line[3:].strip()
+            agent_id = ""
+            title = title_part
+            if "(" in title_part and ")" in title_part:
+                idx = title_part.index("(")
+                title = title_part[:idx].strip()
+                agent_id = title_part[idx + 1 : title_part.index(")")].strip()
+            current = {"title": title, "agent_id": agent_id, "name": "", "duty": ""}
+        elif line.startswith("- 姓名：") and current:
+            current["name"] = line[len("- 姓名：") :].strip()
+        elif line.startswith("- 职责：") and current:
+            current["duty"] = line[len("- 职责：") :].strip()
+
+    if current:
+        roles.append(current)
+
+    return json.dumps({"roles": roles}, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_agents
+# ---------------------------------------------------------------------------
+
+@role_mcp.tool()
+async def get_agents() -> str:
+    """List all registered agents with their status.
+
+    Returns a JSON array with agent_id, display_name, and status
+    for each registered agent.
+    """
+    get_agent_id()  # ensure authenticated
+
+    agents = await _get("agent_registry").list_all()
+    result = [
+        {"agent_id": a.agent_id, "display_name": a.display_name, "status": a.status.value}
+        for a in agents
+    ]
+    return json.dumps(result, ensure_ascii=False)

--- a/packages/server/simu_server/mcp/simu_mcp.py
+++ b/packages/server/simu_server/mcp/simu_mcp.py
@@ -403,6 +403,9 @@ async def push_tape_event(
     agent_id = get_agent_id()
     msg_store = _get("message_store")
 
+    # Force src to authenticated agent to prevent identity spoofing
+    src = f"agent:{agent_id}"
+
     content = payload.get("content", "")
     if not content:
         content = json.dumps(payload, ensure_ascii=False, default=str)

--- a/packages/server/simu_server/mcp/simu_mcp.py
+++ b/packages/server/simu_server/mcp/simu_mcp.py
@@ -1,0 +1,567 @@
+"""simu-mcp — Game interaction + communication MCP server.
+
+Exposes MCP tools for:
+- query_state: read game state
+- create_incident: apply effects to game state (with permission checks)
+- send_message: send messages to other agents / player
+- create_task_session: create a sub-task session
+- finish_task_session: complete or fail a task session
+- push_tape_event: record tape events for observability
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid as _uuid
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+from simu_shared.constants import EventType
+from simu_shared.models import Effect, Incident, RoutedMessage, SessionStatus, TapeEvent
+
+from simu_server.mcp.auth import get_agent_id
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dependency injection (same pattern as routes/callback.py)
+# ---------------------------------------------------------------------------
+
+_deps: dict[str, Any] = {}
+
+
+def set_dependencies(**kwargs: Any) -> None:
+    _deps.update(kwargs)
+
+
+def _get(name: str) -> Any:
+    v = _deps.get(name)
+    if v is None:
+        raise RuntimeError(f"MCP dependency not set: {name}")
+    return v
+
+
+# ---------------------------------------------------------------------------
+# FastMCP server instance
+# ---------------------------------------------------------------------------
+
+simu_mcp = FastMCP("simu-mcp")
+
+
+# ---------------------------------------------------------------------------
+# Tool: query_state
+# ---------------------------------------------------------------------------
+
+@simu_mcp.tool()
+async def query_state(path: str = "") -> str:
+    """Query the current game state.
+
+    Use dot-notation paths to drill into specific data:
+    - "" (empty) → full state snapshot
+    - "nation" → nation-level data
+    - "nation.imperial_treasury" → specific field
+    - "provinces.zhili" → a single province
+    - "provinces.zhili.production_value" → province field
+    """
+    get_agent_id()  # ensure authenticated
+    engine = _get("engine")
+    result = engine.query_state(path)
+    return json.dumps(result, ensure_ascii=False, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Tool: send_message
+# ---------------------------------------------------------------------------
+
+@simu_mcp.tool()
+async def send_message(recipients: list[str], message: str, session_id: str) -> str:
+    """Send a message to other agents or the player.
+
+    Args:
+        recipients: List of target agent IDs (e.g. ["governor_zhili"]) or "player".
+        message: The message content.
+        session_id: The session this message belongs to.
+
+    Returns:
+        JSON with the generated event_id.
+    """
+    agent_id = get_agent_id()
+    msg_store = _get("message_store")
+    queue = _get("queue_controller")
+    ws_mgr = _get("ws_manager")
+
+    dst = [f"agent:{r}" if r != "player" else r for r in recipients]
+    event = TapeEvent(
+        src=f"agent:{agent_id}",
+        dst=dst,
+        event_type=EventType.AGENT_MESSAGE,
+        payload={"content": message},
+        session_id=session_id,
+    )
+
+    msg = RoutedMessage(
+        session_id=session_id,
+        src=f"agent:{agent_id}",
+        dst=dst,
+        content=message,
+        event_type=EventType.AGENT_MESSAGE,
+        origin_event_id=event.event_id,
+    )
+    await msg_store.store(msg)
+
+    for r in recipients:
+        if r != "player":
+            await queue.enqueue(r, event)
+
+    agent_reg = await _get("agent_registry").get(agent_id)
+    display_name = agent_reg.display_name if agent_reg else agent_id
+    await ws_mgr.broadcast({
+        "kind": "chat",
+        "data": {
+            "agent": agent_id,
+            "agentDisplayName": display_name,
+            "text": message,
+            "timestamp": event.timestamp.isoformat(),
+            "session_id": session_id,
+        },
+    })
+
+    return json.dumps({"event_id": event.event_id})
+
+
+# ---------------------------------------------------------------------------
+# Tool: create_incident
+# ---------------------------------------------------------------------------
+
+_MAX_REMAINING_TICKS = 48  # 1 year
+
+
+class EffectParam(BaseModel):
+    """A single effect on a game state field."""
+
+    target_path: str = Field(
+        description=(
+            "Dot-notation path, e.g. 'provinces.zhili.production_value' "
+            "or 'nation.imperial_treasury'"
+        ),
+    )
+    add: str | None = Field(
+        default=None,
+        description="Additive modifier as a decimal string, e.g. '100.5'",
+    )
+    factor: str | None = Field(
+        default=None,
+        description="Multiplicative modifier as a decimal string, e.g. '0.05' for +5%",
+    )
+
+
+@simu_mcp.tool()
+async def create_incident(
+    title: str,
+    description: str,
+    effects: list[EffectParam],
+    remaining_ticks: int,
+    source: str = "",
+) -> str:
+    """Create a game incident that modifies state over time.
+
+    Each effect targets a specific field and applies either an additive
+    (``add``) or multiplicative (``factor``) modifier.  Permission checks
+    are enforced based on the agent's data_scope configuration.
+
+    Args:
+        title: Short incident title.
+        description: Detailed description.
+        effects: List of effects to apply.
+        remaining_ticks: Duration in ticks (1-48, each tick = ~1 month).
+        source: Optional source label (defaults to agent ID).
+
+    Returns:
+        JSON with incident_id and status, or error details.
+    """
+    agent_id = get_agent_id()
+    engine = _get("engine")
+
+    if engine is None:
+        return json.dumps({"error": "Engine not initialized"})
+
+    nation = engine.state.nation
+
+    if remaining_ticks < 1 or remaining_ticks > _MAX_REMAINING_TICKS:
+        return json.dumps({"error": f"remaining_ticks must be 1-{_MAX_REMAINING_TICKS}"})
+
+    if not effects:
+        return json.dumps({"error": "At least one effect is required"})
+
+    scope = _load_data_scope(agent_id)
+    if not scope:
+        return json.dumps({"error": f"Agent {agent_id} has no data_scope configuration"})
+
+    active_incidents = engine.incidents.active
+    errors: list[str] = []
+    for eff in effects:
+        err = _validate_effect(eff, agent_id, scope, nation, active_incidents)
+        if err:
+            errors.append(err)
+
+    if errors:
+        return json.dumps({"error": "; ".join(errors)})
+
+    # Build Effect objects — normalize nation-level paths
+    nation_fields = {"imperial_treasury", "base_tax_rate", "tribute_rate", "fixed_expenditure"}
+    built_effects = []
+    for eff in effects:
+        path = eff.target_path
+        parts = path.split(".")
+        if len(parts) == 1 and parts[0] in nation_fields:
+            path = f"nation.{parts[0]}"
+        kwargs: dict[str, Any] = {"target_path": path}
+        if eff.add is not None:
+            kwargs["add"] = Decimal(eff.add)
+        if eff.factor is not None:
+            kwargs["factor"] = Decimal(eff.factor)
+        built_effects.append(Effect(**kwargs))
+
+    incident = Incident(
+        title=title,
+        description=description,
+        effects=built_effects,
+        remaining_ticks=remaining_ticks,
+        source=source or f"agent:{agent_id}",
+    )
+    engine.add_incident(incident)
+
+    logger.info(
+        "Agent %s created incident '%s' (%d effects, %d ticks)",
+        agent_id, title, len(built_effects), remaining_ticks,
+    )
+    return json.dumps({"incident_id": incident.incident_id, "status": "created"})
+
+
+# ---------------------------------------------------------------------------
+# Tool: create_task_session
+# ---------------------------------------------------------------------------
+
+@simu_mcp.tool()
+async def create_task_session(
+    parent_session_id: str,
+    goal: str,
+    description: str = "",
+    constraints: str = "",
+    timeout_seconds: int = 300,
+    depth: int = 1,
+) -> str:
+    """Create a sub-task session for focused work within a parent session.
+
+    Args:
+        parent_session_id: The parent session to nest under.
+        goal: What this task should accomplish.
+        description: Detailed task description.
+        constraints: Any constraints or limits.
+        timeout_seconds: Maximum duration (default 300s).
+        depth: Nesting depth (max 5).
+
+    Returns:
+        JSON with the new task_session_id.
+    """
+    agent_id = get_agent_id()
+    sm = _get("session_manager")
+    msg_store = _get("message_store")
+
+    task_session_id = f"task:{_uuid.uuid4().hex[:12]}"
+    await sm.create(
+        created_by=f"agent:{agent_id}",
+        parent_id=parent_session_id,
+        session_id=task_session_id,
+    )
+    await sm.add_agent(task_session_id, agent_id)
+    await sm.update_metadata(task_session_id, {
+        "goal": goal,
+        "description": description,
+        "constraints": constraints,
+        "timeout_seconds": timeout_seconds,
+        "depth": depth,
+        "created_by_agent": agent_id,
+    })
+
+    task_event = RoutedMessage(
+        session_id=task_session_id,
+        src=f"agent:{agent_id}",
+        dst=[f"agent:{agent_id}"],
+        content=f"Task created: {goal}",
+        event_type=EventType.TASK_CREATED,
+    )
+    await msg_store.store(task_event)
+
+    logger.info(
+        "Agent %s created task session %s (parent=%s, goal=%s)",
+        agent_id, task_session_id, parent_session_id, goal,
+    )
+    return json.dumps({"task_session_id": task_session_id})
+
+
+# ---------------------------------------------------------------------------
+# Tool: finish_task_session
+# ---------------------------------------------------------------------------
+
+@simu_mcp.tool()
+async def finish_task_session(
+    task_session_id: str,
+    parent_session_id: str,
+    result: str,
+    status: str = "completed",
+) -> str:
+    """Complete or fail a task session.
+
+    Args:
+        task_session_id: The task session to finish.
+        parent_session_id: The parent session.
+        result: Summary of task results.
+        status: "completed" or "failed".
+
+    Returns:
+        JSON status.
+    """
+    agent_id = get_agent_id()
+    sm = _get("session_manager")
+    msg_store = _get("message_store")
+    ws_mgr = _get("ws_manager")
+    queue = _get("queue_controller")
+
+    new_status = SessionStatus.COMPLETED if status == "completed" else SessionStatus.FAILED
+    await sm.update_status(task_session_id, new_status)
+
+    event_type = EventType.TASK_FINISHED if status == "completed" else EventType.TASK_FAILED
+    finish_msg = RoutedMessage(
+        session_id=parent_session_id,
+        src=f"agent:{agent_id}",
+        dst=[f"agent:{agent_id}"],
+        content=result,
+        event_type=event_type,
+    )
+    await msg_store.store(finish_msg)
+
+    if queue:
+        finish_event = TapeEvent(
+            src=f"agent:{agent_id}",
+            dst=[f"agent:{agent_id}"],
+            event_type=event_type,
+            payload={
+                "content": result,
+                "task_session_id": task_session_id,
+                "status": status,
+            },
+            session_id=parent_session_id,
+        )
+        await queue.enqueue(agent_id, finish_event)
+
+    await ws_mgr.broadcast({
+        "kind": "task_finished",
+        "data": {
+            "task_session_id": task_session_id,
+            "parent_session_id": parent_session_id,
+            "status": status,
+            "result": result,
+        },
+    })
+
+    logger.info(
+        "Agent %s finished task session %s (status=%s)",
+        agent_id, task_session_id, status,
+    )
+    return json.dumps({"status": "ok"})
+
+
+# ---------------------------------------------------------------------------
+# Tool: push_tape_event
+# ---------------------------------------------------------------------------
+
+@simu_mcp.tool()
+async def push_tape_event(
+    event_id: str,
+    session_id: str,
+    src: str,
+    dst: list[str],
+    event_type: str,
+    payload: dict,
+    timestamp: str,
+    parent_event_id: str | None = None,
+    route: bool = False,
+) -> str:
+    """Record a tape event for observability.
+
+    When ``route=True`` and event_type is RESPONSE, the event is also
+    delivered to destination agents via the message queue.
+
+    Returns:
+        JSON status.
+    """
+    agent_id = get_agent_id()
+    msg_store = _get("message_store")
+
+    content = payload.get("content", "")
+    if not content:
+        content = json.dumps(payload, ensure_ascii=False, default=str)
+
+    msg = RoutedMessage(
+        message_id=event_id,
+        session_id=session_id,
+        src=src,
+        dst=dst,
+        content=content,
+        event_type=event_type,
+        origin_event_id=parent_event_id,
+    )
+    await msg_store.store(msg)
+
+    if route and event_type == EventType.RESPONSE:
+        queue = _get("queue_controller")
+        event = TapeEvent(
+            event_id=event_id,
+            src=src,
+            dst=dst,
+            event_type=event_type,
+            payload=payload,
+            session_id=session_id,
+            parent_event_id=parent_event_id,
+        )
+        for d in dst:
+            if d.startswith("agent:"):
+                target_id = d.removeprefix("agent:")
+                if target_id != agent_id:
+                    await queue.enqueue(target_id, event)
+
+    return json.dumps({"status": "ok"})
+
+
+# ---------------------------------------------------------------------------
+# Shared validation helpers (extracted from routes/callback.py)
+# ---------------------------------------------------------------------------
+
+def _load_data_scope(agent_id: str) -> dict[str, Any]:
+    """Load data_scope.yaml for an agent.
+
+    Handles both the flat format (provinces/fields/nation_fields at
+    top level) and the legacy V4 format (nested under skills.query_data).
+    """
+    import yaml
+    from simu_server.config import settings
+
+    for base in (settings.default_agents_dir, settings.agents_dir):
+        scope_path = base / agent_id / "data_scope.yaml"
+        if scope_path.exists():
+            raw = yaml.safe_load(scope_path.read_text(encoding="utf-8")) or {}
+            if "provinces" in raw or "fields" in raw or "nation_fields" in raw:
+                return raw
+            query_data = raw.get("skills", {}).get("query_data", {})
+            if query_data:
+                return {
+                    "display_name": raw.get("display_name", ""),
+                    "provinces": query_data.get("provinces", []),
+                    "fields": [f.split(".")[0] for f in query_data.get("fields", [])],
+                    "nation_fields": query_data.get("national", []),
+                }
+            return raw
+    return {}
+
+
+def _validate_effect(
+    effect: EffectParam,
+    agent_id: str,
+    scope: dict[str, Any],
+    nation: Any,
+    active_incidents: list[Any] | None = None,
+) -> str | None:
+    """Validate a single effect against data_scope and game limits.
+
+    Returns an error message string, or None if valid.
+    """
+    parts = effect.target_path.split(".")
+
+    # --- Parse target path ---
+    if parts[0] == "provinces" and len(parts) == 3:
+        province_id, field_name = parts[1], parts[2]
+        allowed_provinces = scope.get("provinces", [])
+        if allowed_provinces != "all" and province_id not in allowed_provinces:
+            return f"权限不足：agent {agent_id} 无权修改省份 {province_id} 的数据"
+        allowed_fields = scope.get("fields", [])
+        if field_name not in allowed_fields:
+            return f"字段不允许：{agent_id} 的 data_scope 不包含省份字段 {field_name}"
+        province = nation.provinces.get(province_id)
+        if province is None:
+            return f"省份不存在：{province_id}"
+        current = getattr(province, field_name, None)
+        if current is None or not isinstance(current, Decimal):
+            return f"字段无效：{field_name} 不是有效的数值字段"
+
+    elif (len(parts) == 1) or (len(parts) == 2 and parts[0] == "nation"):
+        field_name = parts[-1]
+        allowed_nation_fields = scope.get("nation_fields", [])
+        if field_name not in allowed_nation_fields:
+            return f"字段不允许：{agent_id} 的 data_scope 不包含国家级别字段 {field_name}"
+        current = getattr(nation, field_name, None)
+        if current is None or not isinstance(current, Decimal):
+            return f"字段无效：{field_name} 不是有效的国家级数值字段"
+    else:
+        return (
+            f"target_path 格式错误：{effect.target_path}"
+            f"（应为 'provinces.{{id}}.{{field}}' 或 'nation.{{field}}'）"
+        )
+
+    # --- Value validation ---
+    if effect.add is not None and effect.factor is not None:
+        return "Effect 必须只有 add 或 factor 之一，不能同时设置"
+    if effect.add is None and effect.factor is None:
+        return "Effect 必须设置 add 或 factor 之一"
+
+    _allow_non_positive = {"tax_modifier", "base_production_growth", "base_population_growth"}
+
+    nation_field_names = {
+        "imperial_treasury", "base_tax_rate", "tribute_rate", "fixed_expenditure",
+    }
+    canonical_path = effect.target_path
+    if len(parts) == 1 and parts[0] in nation_field_names:
+        canonical_path = f"nation.{parts[0]}"
+
+    existing_factors: list[Decimal] = []
+    existing_unapplied_adds: list[Decimal] = []
+    if active_incidents:
+        for incident in active_incidents:
+            for eff in incident.effects:
+                if eff.target_path != canonical_path:
+                    continue
+                if eff.factor is not None:
+                    existing_factors.append(eff.factor)
+                if eff.add is not None and not incident.applied:
+                    existing_unapplied_adds.append(eff.add)
+
+    try:
+        if effect.add is not None:
+            add_val = Decimal(effect.add)
+            simulated = current + sum(existing_unapplied_adds) + add_val
+            if field_name not in _allow_non_positive and simulated <= 0:
+                return (
+                    f"数值溢出：add={effect.add} 会将 {effect.target_path} "
+                    f"（当前值 {current}，已有未生效 add 合计 "
+                    f"{sum(existing_unapplied_adds)}）减至 {simulated}（≤ 0）"
+                )
+        if effect.factor is not None:
+            factor_val = Decimal(effect.factor)
+            simulated = current
+            for ef in existing_factors:
+                simulated *= Decimal("1") + ef
+            simulated *= Decimal("1") + factor_val
+            if field_name not in _allow_non_positive and simulated <= 0:
+                return (
+                    f"数值溢出：factor={effect.factor} 叠加已有修改后会将 "
+                    f"{effect.target_path}（当前值 {current}）变为 "
+                    f"{simulated}（≤ 0）"
+                )
+    except InvalidOperation:
+        return f"数值格式错误：add={effect.add}, factor={effect.factor}"
+
+    return None

--- a/packages/server/simu_server/services/event_router.py
+++ b/packages/server/simu_server/services/event_router.py
@@ -55,7 +55,9 @@ class EventRouter:
     async def broadcast(self, event: TapeEvent) -> list[str]:
         """Send *event* to all connected agents."""
         delivered: list[str] = []
-        for agent_id, q in self._queues.items():
+        # Snapshot to avoid RuntimeError if a connect/disconnect mutates
+        # _queues during iteration (e.g. an agent disconnects while we broadcast).
+        for agent_id, q in list(self._queues.items()):
             try:
                 q.put_nowait(event)
                 delivered.append(agent_id)

--- a/packages/server/simu_server/services/queue_controller.py
+++ b/packages/server/simu_server/services/queue_controller.py
@@ -38,16 +38,16 @@ class QueueController:
             logger.warning("Queue full for agent %s, rejecting event", agent_id)
             return False
         await q.put(event)
-        # Kick off processing if not already running
+        # Kick off processing if not already running.
+        # Add to _processing BEFORE creating the task to prevent the TOCTOU
+        # race where two enqueue() calls both see agent_id not in _processing.
         if agent_id not in self._processing:
+            self._processing.add(agent_id)
             asyncio.create_task(self._process_loop(agent_id))
         return True
 
     async def _process_loop(self, agent_id: str) -> None:
         """Drain the queue for *agent_id*, one event at a time."""
-        if agent_id in self._processing:
-            return
-        self._processing.add(agent_id)
 
         try:
             q = self._queues[agent_id]


### PR DESCRIPTION
## Summary

- **MCP Server Layer**: Extract callback.py endpoints into two MCP servers as specified in the V6 architecture design
  - `simu-mcp` (mounted at `/mcp/simu`): 6 tools — query_state, send_message, create_incident, create_task_session, finish_task_session, push_tape_event
  - `role-mcp` (mounted at `/mcp/role`): 2 tools — query_role_map, get_agents
- **Auth**: Raw ASGI middleware validates `X-Agent-Id` / `X-Callback-Token` headers, sets `contextvars.ContextVar` so MCP tools access the authenticated agent ID without it being a tool parameter (prevents identity spoofing)
- **Transport**: Streamable-HTTP via `FastMCP.streamable_http_app()`, mounted in the existing FastAPI app — shares service instances, no inter-process overhead
- **V5 Bug Fixes**:
  - `QueueController`: Fix TOCTOU race — `_processing.add()` now before `create_task()` to prevent duplicate dispatch loops
  - `EventRouter`: Fix broadcast iteration race — snapshot `_queues` with `list()` before iterating

## Architecture

```
Agent ──MCP Protocol──► /mcp/simu (MCPAuthMiddleware → simu-mcp FastMCP)
                        /mcp/role (MCPAuthMiddleware → role-mcp FastMCP)
                        /api/callback/events (SSE — retained for event push)
```

The existing callback endpoints remain functional for backward compatibility during migration.

## New Files

- `packages/server/simu_server/mcp/__init__.py` — package exports
- `packages/server/simu_server/mcp/auth.py` — ASGI auth middleware + context var
- `packages/server/simu_server/mcp/simu_mcp.py` — simu-mcp server (game + channel tools)
- `packages/server/simu_server/mcp/role_mcp.py` — role-mcp server (role tools)

## Test plan

- [ ] Verify server starts without errors (`uv run simu-emperor`)
- [ ] Verify MCP tool listing via MCP client connection to `/mcp/simu/mcp` and `/mcp/role/mcp`
- [ ] Verify auth middleware rejects requests without valid headers
- [ ] Verify `query_state` returns correct game data through MCP
- [ ] Verify `create_incident` permission checks match callback.py behavior
- [ ] Verify QueueController no longer double-dispatches under concurrent enqueue

🤖 Generated with [Claude Code](https://claude.com/claude-code)