### PR TITLE
feat: Phase 2 rich content blocks

### DIFF
--- a/docs/design/rich-content-blocks-spec.md
+++ b/docs/design/rich-content-blocks-spec.md
@@ -1,0 +1,361 @@
+# Rich Content Blocks Spec (Phase 2)
+
+> Frontend 富内容渲染规范，参考 clowder-ai 的 Rich Content Block 设计。
+> Phase 1（组件拆分 + Zustand + Agent 视觉身份）完成后开始实施。
+
+## 设计原则
+
+1. **结构化优于纯文本** — TapeEvent 的 payload 包含结构化数据，应以卡片/表格等形式渲染，而非 JSON dump
+2. **折叠优先** — 详细信息默认折叠，一级信息直接可见
+3. **Agent 身份贯穿** — 每个 block 继承所属 Agent 的颜色系统
+4. **三层分离** — 遵循 Phase 1 建立的消息分层：Agent 对话 / 系统事件 / 工具执行
+
+## Block 类型定义
+
+### 1. ToolCallBlock
+
+**触发条件：** `event.type === "tool_call"`
+
+**Payload 结构（来自 `react.py:_record_tool_calls`）：**
+```typescript
+interface ToolCallPayload {
+  reasoning: string;         // LLM 的推理过程
+  tool_calls: {
+    name: string;            // 工具名称
+    arguments: Record<string, unknown>;  // 工具参数
+  }[];
+}
+```
+
+**渲染方案：**
+```
+┌─ 🔧 工具调用 ──────────────────────────────────────┐
+│                                                       │
+│  [reasoning 文本，markdown 渲染，默认折叠]              │
+│                                                       │
+│  ┌─ send_message ─────────────────────────────┐      │
+│  │  recipients: ["governor_zhili"]             │      │
+│  │  message: "请问直隶今年税收情况..."           │      │
+│  └────────────────────────────────────────────┘      │
+│  ┌─ query_state ──────────────────────────────┐      │
+│  │  path: "provinces.zhili"                    │      │
+│  └────────────────────────────────────────────┘      │
+└───────────────────────────────────────────────────────┘
+```
+
+**组件接口：**
+```typescript
+interface ToolCallBlockProps {
+  reasoning: string;
+  toolCalls: { name: string; arguments: Record<string, unknown> }[];
+  agentColor: string;  // 从 agent-tokens 获取
+}
+```
+
+**交互：**
+- reasoning 默认折叠，点击展开
+- 每个 tool call 显示为独立小卡片
+- arguments 中已知字段特殊渲染（如 recipients 显示为 badge 列表）
+
+---
+
+### 2. ToolResultBlock
+
+**触发条件：** `event.type === "tool_result"`
+
+**Payload 结构（来自 `react.py:_record_tool_result`）：**
+```typescript
+interface ToolResultPayload {
+  tool: string;           // 工具名称
+  arguments: Record<string, unknown>;  // 调用参数
+  result: string;         // 执行结果（可能是 JSON string）
+  ends_loop?: boolean;    // 是否终止 ReAct 循环
+}
+```
+
+**渲染方案：**
+```
+┌─ ✅ query_state 结果 ─────────────────────────────┐
+│  path: "provinces.zhili"                            │
+│  ┌─ 结果 ───────────────────────────────────────┐  │
+│  │  production_value: 125,000                    │  │
+│  │  population: 3,200,000                        │  │
+│  │  tax_modifier: +0.02                          │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+**特殊工具渲染：**
+
+| 工具 | 渲染方式 |
+|------|---------|
+| `query_state` | 尝试 JSON.parse result，以表格渲染省份/国家数据 |
+| `send_message` | 显示消息预览 + 收件人 badge |
+| `create_incident` | 渲染为 IncidentBlock（见下） |
+| `search_memory` | 记忆检索结果列表 |
+| 其他 | 默认纯文本/代码块 |
+
+**组件接口：**
+```typescript
+interface ToolResultBlockProps {
+  tool: string;
+  arguments: Record<string, unknown>;
+  result: string;
+  endsLoop?: boolean;
+  agentColor: string;
+}
+```
+
+---
+
+### 3. IncidentBlock
+
+**触发条件：** `event.type === "incident_created"` 或 ToolResult 中 `tool === "create_incident"`
+
+**渲染方案：**
+```
+┌─ ⚡ 事件：江南水患 ──────────────────────────────────┐
+│  来源: governor_jiangnan (江南巡抚)                     │
+│  持续: 3 个 tick                                       │
+│                                                        │
+│  影响:                                                 │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  📉 江南产值增长率  ×0.8  (-20%)                  │  │
+│  │  📈 江南税率修正    +0.05                         │  │
+│  └──────────────────────────────────────────────────┘  │
+│                                                        │
+│  描述: 连日暴雨导致江南多地受灾，产值增长放缓...         │
+└────────────────────────────────────────────────────────┘
+```
+
+**组件接口：**
+```typescript
+interface IncidentBlockProps {
+  title: string;
+  description: string;
+  source: string;
+  remainingTicks: number;
+  effects: {
+    target_path: string;
+    add: string | null;
+    factor: string | null;
+  }[];
+}
+```
+
+**效果展示规则：**
+- `factor` 显示为百分比变化（如 `0.8` → `-20%`）
+- `add` 显示为绝对值变化（如 `0.05` → `+0.05`）
+- `target_path` 解析为可读名称（如 `provinces.jiangnan.production_growth` → `江南产值增长率`）
+
+---
+
+### 4. TaskSessionBlock
+
+**触发条件：** `event.type === "task_created" | "task_finished" | "task_failed" | "task_timeout"`
+
+**Payload 结构：**
+```typescript
+// task_created
+interface TaskCreatedPayload {
+  goal: string;
+  task_session_id: string;
+  parent_session_id: string;
+  depth: number;
+}
+
+// task_finished
+interface TaskFinishedPayload {
+  task_session_id: string;
+  result: string;
+  status: "completed";
+}
+
+// task_failed / task_timeout
+interface TaskFailedPayload {
+  task_session_id: string;
+  reason: string;
+  status: "failed" | "timeout";
+}
+```
+
+**渲染方案：**
+```
+┌─ 📋 任务会话 ────────────────────────────────────────┐
+│  🟢 已完成                                            │
+│  目标: 协调各省税收调整方案                              │
+│  会话: task:abc123...                                  │
+│  层级: 2 / 5                                          │
+│                                                       │
+│  [展开查看子会话事件]                                   │
+│                                                       │
+│  结果: 已与直隶巡抚和户部尚书达成共识，建议...            │
+└───────────────────────────────────────────────────────┘
+```
+
+**状态颜色：**
+- `task_created`: 蓝色 🔵
+- `task_finished`: 绿色 🟢
+- `task_failed`: 红色 🔴
+- `task_timeout`: 橙色 🟠
+
+**交互：**
+- 子会话事件可展开查看（调用 `/api/tape/subsessions` 获取）
+- 深度用进度条展示（depth / MAX_TASK_DEPTH）
+
+---
+
+### 5. SystemNoticeBar
+
+**触发条件：** `event.type === "tick_completed" | "system" | "shutdown" | "reload_config"`
+
+**渲染方案：** 全宽通知栏，不使用气泡样式
+
+```
+──── ⏰ 雍正2年3月 第2周 ── 国库: 1,250,000 (+12,500) ── 人口: 15,200,000 (+50,000) ────
+```
+
+```
+──── ⚠️ 系统: agent governor_zhili 已重新加载配置 ────
+```
+
+**组件接口：**
+```typescript
+interface SystemNoticeBarProps {
+  type: "tick" | "system" | "shutdown" | "reload";
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+```
+
+---
+
+### 6. AgentMessageBlock（增强）
+
+**触发条件：** `event.type === "agent_message"` 且 `dst` 包含其他 agent
+
+**场景：** Agent 之间的对话（非回复玩家的消息）
+
+**渲染方案：**
+```
+┌─ 💬 江南巡抚 → 户部尚书 ─────────────────────────────┐
+│                                                       │
+│  关于今年江南的税收调整，我有以下建议...                  │
+│  [markdown 正文]                                       │
+│                                                       │
+│  ⏳ 等待回复中...                                      │
+└───────────────────────────────────────────────────────┘
+```
+
+**增强点：**
+- 显示消息路由方向（src → dst）
+- 等待回复时显示 pending 状态
+- agent-to-agent 消息用虚线边框区分于 agent-to-player
+
+---
+
+## Block 选择器逻辑
+
+```typescript
+// components/rich/BlockSelector.tsx
+
+function selectBlock(event: TapeEvent): React.ComponentType<any> | null {
+  const type = event.type.toLowerCase();
+  
+  switch (type) {
+    case 'tool_call':
+      return ToolCallBlock;
+    case 'tool_result':
+      return ToolResultBlock;
+    case 'incident_created':
+      return IncidentBlock;
+    case 'task_created':
+    case 'task_finished':
+    case 'task_failed':
+    case 'task_timeout':
+      return TaskSessionBlock;
+    case 'tick_completed':
+    case 'system':
+    case 'shutdown':
+    case 'reload_config':
+      return SystemNoticeBar;
+    case 'agent_message':
+      // agent-to-agent 用增强渲染，agent-to-player 用普通气泡
+      if (!event.dst.some(d => d.startsWith('player'))) {
+        return AgentMessageBlock;
+      }
+      return null; // 使用默认 MessageBubble
+    default:
+      return null; // 使用默认 MessageBubble
+  }
+}
+```
+
+## 在 TAPE CONTEXT 面板中的展示
+
+TAPE CONTEXT（右侧面板底部）显示原始事件流，应使用 block 系统渲染：
+
+- 所有事件类型都应通过 `BlockSelector` 渲染
+- 与聊天区的区别：TAPE CONTEXT 显示**全部**事件（包括 tool_call/tool_result），聊天区只显示对话
+- TAPE CONTEXT 中的 block 默认折叠，节省空间
+
+## 目标路径可读名称映射
+
+```typescript
+// theme/path-labels.ts
+
+const PATH_LABELS: Record<string, string> = {
+  'imperial_treasury': '国库',
+  'base_tax_rate': '基础税率',
+  'tribute_rate': '上缴率',
+  'fixed_expenditure': '固定支出',
+  'provinces.jiangnan.production_value': '江南产值',
+  'provinces.jiangnan.population': '江南人口',
+  'provinces.jiangnan.tax_modifier': '江南税率修正',
+  'provinces.jiangnan.production_growth': '江南产值增长率',
+  'provinces.jiangnan.population_growth': '江南人口增长率',
+  'provinces.zhili.production_value': '直隶产值',
+  'provinces.zhili.population': '直隶人口',
+  'provinces.zhili.tax_modifier': '直隶税率修正',
+  'provinces.zhili.production_growth': '直隶产值增长率',
+  'provinces.zhili.population_growth': '直隶人口增长率',
+  // ... 动态生成：通过 agent 列表 + 省份列表组合
+};
+
+function resolvePathLabel(path: string): string {
+  return PATH_LABELS[path] || path;
+}
+```
+
+## 依赖
+
+Phase 2 不引入新的 npm 依赖：
+- Markdown 渲染：复用现有 `react-markdown` + `remark-gfm`
+- 图标：复用现有 `lucide-react`
+- 样式：Tailwind + CSS custom properties（Phase 1 已建立）
+
+## 文件结构
+
+```
+src/components/rich/
+├── BlockSelector.tsx         # 根据 event.type 选择 block 组件
+├── ToolCallBlock.tsx         # 工具调用渲染
+├── ToolResultBlock.tsx       # 工具结果渲染
+├── IncidentBlock.tsx         # 事件卡片
+├── TaskSessionBlock.tsx      # 任务会话卡片
+├── SystemNoticeBar.tsx       # 系统通知栏
+├── AgentMessageBlock.tsx     # Agent 间消息增强渲染
+└── shared/
+    ├── CollapsibleSection.tsx  # 可折叠区域
+    ├── JsonTable.tsx           # JSON 对象表格渲染
+    └── AgentBadge.tsx          # Agent 标识（复用 Phase 1）
+```
+
+## 实施顺序
+
+1. `BlockSelector` + `SystemNoticeBar`（最简单，验证 block 选择机制）
+2. `ToolCallBlock` + `ToolResultBlock`（频率最高的事件类型）
+3. `IncidentBlock`（游戏核心功能可视化）
+4. `TaskSessionBlock`（任务会话层级展示）
+5. `AgentMessageBlock`（增强 agent 间通信展示）
+6. TAPE CONTEXT 面板集成（全部事件用 block 渲染）

--- a/packages/server/simu_server/mcp/simu_mcp.py
+++ b/packages/server/simu_server/mcp/simu_mcp.py
@@ -451,6 +451,7 @@ async def push_tape_event(
         content=content,
         event_type=event_type,
         origin_event_id=parent_event_id,
+        payload_json=json.dumps(payload, ensure_ascii=False, default=str),
     )
     await msg_store.store(msg)
 

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -5,6 +5,7 @@ Preserves all V4 Web API functionality per design constraint.
 
 from __future__ import annotations
 
+import json
 from decimal import Decimal
 from typing import Any
 
@@ -542,7 +543,7 @@ async def get_current_tape(
             "src": m.src,
             "dst": m.dst,
             "type": m.event_type,
-            "payload": {"content": m.content},
+            "payload": json.loads(m.payload_json) if m.payload_json else {"content": m.content},
             "timestamp": m.timestamp.isoformat() if m.timestamp else "",
             "session_id": m.session_id,
             "agent_id": agent_id,

--- a/packages/server/simu_server/services/message_store.py
+++ b/packages/server/simu_server/services/message_store.py
@@ -25,8 +25,8 @@ class MessageStore:
     async def store(self, msg: RoutedMessage) -> None:
         await self._db.conn.execute(
             """
-            INSERT INTO messages (message_id, session_id, src, dst, content, event_type, timestamp, origin_event_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO messages (message_id, session_id, src, dst, content, event_type, timestamp, origin_event_id, payload_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 msg.message_id,
@@ -37,6 +37,7 @@ class MessageStore:
                 msg.event_type,
                 msg.timestamp.isoformat(),
                 msg.origin_event_id,
+                msg.payload_json,
             ),
         )
         await self._db.conn.commit()
@@ -104,4 +105,5 @@ class MessageStore:
             event_type=row[5],
             timestamp=row[6],
             origin_event_id=row[7],
+            payload_json=row[8] if len(row) > 8 else None,
         )

--- a/packages/server/simu_server/stores/database.py
+++ b/packages/server/simu_server/stores/database.py
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS messages (
     content       TEXT NOT NULL,
     event_type    TEXT NOT NULL,
     timestamp     TEXT NOT NULL,
-    origin_event_id TEXT
+    origin_event_id TEXT,
+    payload_json  TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages (session_id, timestamp);
 
@@ -94,8 +95,18 @@ class Database:
         self._conn = await aiosqlite.connect(str(self._db_path))
         await self._conn.execute("PRAGMA journal_mode=WAL")
         await self._conn.executescript(_SCHEMA)
+        await self._migrate(self._conn)
         await self._conn.commit()
         logger.info("Database initialized at %s", self._db_path)
+
+    @staticmethod
+    async def _migrate(conn: aiosqlite.Connection) -> None:
+        """Apply incremental schema migrations for existing databases."""
+        cursor = await conn.execute("PRAGMA table_info(messages)")
+        columns = {row[1] for row in await cursor.fetchall()}
+        if "payload_json" not in columns:
+            await conn.execute("ALTER TABLE messages ADD COLUMN payload_json TEXT")
+            logger.info("Migrated messages table: added payload_json column")
 
     @property
     def conn(self) -> aiosqlite.Connection:

--- a/packages/shared/simu_shared/models.py
+++ b/packages/shared/simu_shared/models.py
@@ -106,6 +106,7 @@ class RoutedMessage(BaseModel):
     event_type: str
     timestamp: datetime = Field(default_factory=_utcnow)
     origin_event_id: str | None = None  # points to source TapeEvent
+    payload_json: str | None = None  # full TapeEvent payload as JSON string
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/components/layout/RightSidebar.tsx
+++ b/web/src/components/layout/RightSidebar.tsx
@@ -13,6 +13,7 @@ import { useAgentStore } from '../../stores/agentStore';
 import { useChatStore } from '../../stores/chatStore';
 import { formatTurn } from '../../utils/format';
 import { extractEventText, getTapeEventStyle } from '../../utils/tape';
+import { BlockSelector, hasRichBlock } from '../rich/BlockSelector';
 import { OverviewPanel } from '../empire/OverviewPanel';
 import { IncidentPanel } from '../empire/IncidentPanel';
 import { ProvincePanel } from '../empire/ProvincePanel';
@@ -302,6 +303,13 @@ export function RightSidebar({
             )}
 
             {tapeContextEvents.map((event) => {
+              if (hasRichBlock(event)) {
+                return (
+                  <div key={event.event_id}>
+                    <BlockSelector event={event} compact />
+                  </div>
+                );
+              }
               const style = getTapeEventStyle(event.type);
               return (
                 <div key={event.event_id} className={`rounded-xl border p-3 ${style.cardClass}`}>

--- a/web/src/components/rich/AgentMessageBlock.tsx
+++ b/web/src/components/rich/AgentMessageBlock.tsx
@@ -1,0 +1,50 @@
+import { MessageCircle } from 'lucide-react';
+
+import type { TapeEvent } from '../../api/types';
+import { getAgentToken } from '../../theme/agent-tokens';
+import { extractEventText } from '../../utils/tape';
+import { renderMarkdown } from '../../utils/render';
+import { formatDate } from '../../utils/format';
+
+interface AgentMessageBlockProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+export function AgentMessageBlock({ event, compact = false }: AgentMessageBlockProps) {
+  const srcId = event.src.replace('agent:', '');
+  const srcToken = getAgentToken(srcId);
+  const dstNames = event.dst
+    .map((d) => {
+      const id = d.replace('agent:', '');
+      return getAgentToken(id).displayName;
+    })
+    .join(', ');
+
+  const text = extractEventText(event);
+
+  return (
+    <div
+      className="rounded-xl border border-dashed px-3 py-2"
+      style={{ borderColor: `${srcToken.color}60`, backgroundColor: `${srcToken.bgColor}50` }}
+    >
+      <div className="mb-1 flex items-center gap-2">
+        <MessageCircle className="h-3.5 w-3.5" style={{ color: srcToken.color }} />
+        <span className="text-xs font-semibold" style={{ color: srcToken.color }}>
+          {srcToken.icon} {srcToken.displayName}
+        </span>
+        <span className="text-xs text-slate-400">{'>'}</span>
+        <span className="text-xs text-slate-600">{dstNames}</span>
+        <span className="ml-auto text-[10px] text-slate-400">{formatDate(event.timestamp)}</span>
+      </div>
+
+      {text && (
+        compact ? (
+          <p className="text-xs text-slate-600 line-clamp-2">{text}</p>
+        ) : (
+          renderMarkdown(text, false)
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/components/rich/BlockSelector.tsx
+++ b/web/src/components/rich/BlockSelector.tsx
@@ -1,0 +1,82 @@
+import type { TapeEvent } from '../../api/types';
+import { isPlayerMessage } from '../../utils/tape';
+import { ToolCallBlock } from './ToolCallBlock';
+import { ToolResultBlock } from './ToolResultBlock';
+import { IncidentBlock } from './IncidentBlock';
+import { TaskSessionBlock } from './TaskSessionBlock';
+import { SystemNoticeBar } from './SystemNoticeBar';
+import { AgentMessageBlock } from './AgentMessageBlock';
+
+interface BlockSelectorProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+/**
+ * Selects and renders the appropriate rich content block for a TapeEvent.
+ * Returns null if the event should use the default rendering (e.g., MessageBubble).
+ */
+export function BlockSelector({ event, compact = false }: BlockSelectorProps) {
+  const type = event.type.toLowerCase();
+
+  switch (type) {
+    case 'tool_call':
+      return <ToolCallBlock event={event} compact={compact} />;
+
+    case 'tool_result':
+      return <ToolResultBlock event={event} compact={compact} />;
+
+    case 'incident_created':
+      return <IncidentBlock event={event} compact={compact} />;
+
+    case 'task_created':
+    case 'task_finished':
+    case 'task_failed':
+    case 'task_timeout':
+      return <TaskSessionBlock event={event} compact={compact} />;
+
+    case 'tick_completed':
+    case 'system':
+    case 'shutdown':
+    case 'reload_config':
+      return <SystemNoticeBar event={event} />;
+
+    case 'agent_message':
+    case 'response':
+      // Agent-to-agent messages get enhanced rendering; agent-to-player uses default MessageBubble
+      if (!event.dst.some((d) => isPlayerMessage(d) || d === 'player')) {
+        return <AgentMessageBlock event={event} compact={compact} />;
+      }
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Returns true if the event has a rich block renderer.
+ * Used by containers to decide whether to use BlockSelector or default rendering.
+ */
+export function hasRichBlock(event: TapeEvent): boolean {
+  const type = event.type.toLowerCase();
+  switch (type) {
+    case 'tool_call':
+    case 'tool_result':
+    case 'incident_created':
+    case 'task_created':
+    case 'task_finished':
+    case 'task_failed':
+    case 'task_timeout':
+    case 'tick_completed':
+    case 'system':
+    case 'shutdown':
+    case 'reload_config':
+      return true;
+    case 'agent_message':
+    case 'response':
+      return !event.dst.some((d) => isPlayerMessage(d) || d === 'player');
+    default:
+      return false;
+  }
+}

--- a/web/src/components/rich/IncidentBlock.tsx
+++ b/web/src/components/rich/IncidentBlock.tsx
@@ -1,0 +1,106 @@
+import { Zap } from 'lucide-react';
+
+import type { TapeEvent } from '../../api/types';
+
+const PATH_LABELS: Record<string, string> = {
+  imperial_treasury: '国库',
+  base_tax_rate: '基础税率',
+  tribute_rate: '上缴率',
+  fixed_expenditure: '固定支出',
+};
+
+function resolvePathLabel(path: string): string {
+  if (PATH_LABELS[path]) return PATH_LABELS[path];
+
+  // Try to resolve province-specific paths
+  const match = path.match(/^provinces\.(\w+)\.(\w+)$/);
+  if (match) {
+    const [, province, field] = match;
+    const provinceNames: Record<string, string> = {
+      jiangnan: '江南',
+      zhili: '直隶',
+    };
+    const fieldNames: Record<string, string> = {
+      production_value: '产值',
+      population: '人口',
+      tax_modifier: '税率修正',
+      fixed_expenditure: '固定支出',
+      stockpile: '库存',
+      base_production_growth: '产值增长率',
+      base_population_growth: '人口增长率',
+    };
+    const pName = provinceNames[province] || province;
+    const fName = fieldNames[field] || field;
+    return `${pName}${fName}`;
+  }
+
+  return path;
+}
+
+function formatEffect(effect: { target_path: string; add?: string | null; factor?: string | null }) {
+  const label = resolvePathLabel(effect.target_path);
+  if (effect.factor && effect.factor !== '1') {
+    const factor = parseFloat(effect.factor);
+    const pct = ((factor - 1) * 100).toFixed(0);
+    const sign = factor >= 1 ? '+' : '';
+    return { label, value: `x${effect.factor} (${sign}${pct}%)`, isNegative: factor < 1 };
+  }
+  if (effect.add) {
+    const num = parseFloat(effect.add);
+    const sign = num >= 0 ? '+' : '';
+    return { label, value: `${sign}${effect.add}`, isNegative: num < 0 };
+  }
+  return { label, value: '-', isNegative: false };
+}
+
+interface IncidentBlockProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+export function IncidentBlock({ event, compact = false }: IncidentBlockProps) {
+  const payload = event.payload ?? {};
+  const title = typeof payload.title === 'string' ? payload.title : '事件';
+  const description = typeof payload.description === 'string' ? payload.description : '';
+  const source = typeof payload.source === 'string' ? payload.source : event.src;
+  const remainingTicks = typeof payload.remaining_ticks === 'number' ? payload.remaining_ticks : null;
+  const effects = Array.isArray(payload.effects) ? payload.effects as { target_path: string; add?: string | null; factor?: string | null }[] : [];
+
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50/70 px-3 py-2">
+      <div className="mb-1 flex items-center gap-2">
+        <Zap className="h-3.5 w-3.5 text-amber-600" />
+        <span className="text-xs font-semibold text-amber-800">{title}</span>
+        {remainingTicks !== null && (
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700">
+            {remainingTicks} tick
+          </span>
+        )}
+      </div>
+
+      {source && (
+        <p className="mb-1 text-[10px] text-amber-600">来源: {source}</p>
+      )}
+
+      {effects.length > 0 && (
+        <div className="mb-1 space-y-0.5">
+          {effects.map((effect, i) => {
+            const formatted = formatEffect(effect);
+            return (
+              <div key={i} className="flex items-center justify-between rounded bg-white/60 px-2 py-1 text-xs">
+                <span className="text-slate-700">{formatted.label}</span>
+                <span className={formatted.isNegative ? 'font-medium text-red-600' : 'font-medium text-emerald-600'}>
+                  {formatted.value}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {description && !compact && (
+        <p className="mt-1 text-xs text-amber-700">{description}</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/rich/SystemNoticeBar.tsx
+++ b/web/src/components/rich/SystemNoticeBar.tsx
@@ -1,0 +1,71 @@
+import type { TapeEvent } from '../../api/types';
+import { formatTurn } from '../../utils/format';
+
+interface SystemNoticeBarProps {
+  event: TapeEvent;
+}
+
+export function SystemNoticeBar({ event }: SystemNoticeBarProps) {
+  const type = event.type.toLowerCase();
+  const payload = event.payload ?? {};
+
+  if (type === 'tick_completed') {
+    const turn = typeof payload.turn === 'number' ? payload.turn : null;
+    const treasury = typeof payload.treasury === 'number' ? payload.treasury : null;
+    const population = typeof payload.population === 'number' ? payload.population : null;
+    const treasuryDelta = typeof payload.treasury_delta === 'number' ? payload.treasury_delta : null;
+    const populationDelta = typeof payload.population_delta === 'number' ? payload.population_delta : null;
+
+    const parts: string[] = [];
+    if (turn !== null) parts.push(formatTurn(turn));
+    if (treasury !== null) {
+      const delta = treasuryDelta !== null ? ` (${treasuryDelta >= 0 ? '+' : ''}${treasuryDelta.toLocaleString('zh-CN')})` : '';
+      parts.push(`国库: ${treasury.toLocaleString('zh-CN')}${delta}`);
+    }
+    if (population !== null) {
+      const delta = populationDelta !== null ? ` (${populationDelta >= 0 ? '+' : ''}${populationDelta.toLocaleString('zh-CN')})` : '';
+      parts.push(`人口: ${population.toLocaleString('zh-CN')}${delta}`);
+    }
+
+    return (
+      <div className="flex items-center justify-center gap-3 rounded-lg bg-amber-50 px-4 py-2 text-xs text-amber-700">
+        <span className="text-amber-500">---</span>
+        <span>{parts.length > 0 ? parts.join(' | ') : '回合结算'}</span>
+        <span className="text-amber-500">---</span>
+      </div>
+    );
+  }
+
+  if (type === 'shutdown') {
+    return (
+      <div className="flex items-center justify-center gap-2 rounded-lg bg-red-50 px-4 py-2 text-xs text-red-600">
+        <span>---</span>
+        <span>Agent 已关闭</span>
+        <span>---</span>
+      </div>
+    );
+  }
+
+  if (type === 'reload_config') {
+    return (
+      <div className="flex items-center justify-center gap-2 rounded-lg bg-blue-50 px-4 py-2 text-xs text-blue-600">
+        <span>---</span>
+        <span>配置已重新加载</span>
+        <span>---</span>
+      </div>
+    );
+  }
+
+  // Generic system event
+  const text = typeof payload.content === 'string' ? payload.content
+    : typeof payload.message === 'string' ? payload.message
+    : event.type;
+
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-lg bg-slate-50 px-4 py-2 text-xs text-slate-500">
+      <span>---</span>
+      <span>{text}</span>
+      <span>---</span>
+    </div>
+  );
+}

--- a/web/src/components/rich/TaskSessionBlock.tsx
+++ b/web/src/components/rich/TaskSessionBlock.tsx
@@ -1,0 +1,98 @@
+import { ClipboardCheck, ClipboardX, Clock, ListTodo } from 'lucide-react';
+
+import type { TapeEvent } from '../../api/types';
+
+interface TaskSessionBlockProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+const STATUS_CONFIG = {
+  task_created: {
+    icon: ListTodo,
+    label: '任务创建',
+    bgClass: 'bg-blue-50/70',
+    borderClass: 'border-blue-200',
+    iconClass: 'text-blue-600',
+    labelClass: 'text-blue-800',
+    badgeClass: 'bg-blue-100 text-blue-700',
+  },
+  task_finished: {
+    icon: ClipboardCheck,
+    label: '任务完成',
+    bgClass: 'bg-emerald-50/70',
+    borderClass: 'border-emerald-200',
+    iconClass: 'text-emerald-600',
+    labelClass: 'text-emerald-800',
+    badgeClass: 'bg-emerald-100 text-emerald-700',
+  },
+  task_failed: {
+    icon: ClipboardX,
+    label: '任务失败',
+    bgClass: 'bg-red-50/70',
+    borderClass: 'border-red-200',
+    iconClass: 'text-red-600',
+    labelClass: 'text-red-800',
+    badgeClass: 'bg-red-100 text-red-700',
+  },
+  task_timeout: {
+    icon: Clock,
+    label: '任务超时',
+    bgClass: 'bg-orange-50/70',
+    borderClass: 'border-orange-200',
+    iconClass: 'text-orange-600',
+    labelClass: 'text-orange-800',
+    badgeClass: 'bg-orange-100 text-orange-700',
+  },
+} as const;
+
+export function TaskSessionBlock({ event, compact = false }: TaskSessionBlockProps) {
+  const type = event.type.toLowerCase() as keyof typeof STATUS_CONFIG;
+  const config = STATUS_CONFIG[type] || STATUS_CONFIG.task_created;
+  const Icon = config.icon;
+  const payload = event.payload ?? {};
+
+  const goal = typeof payload.goal === 'string' ? payload.goal : '';
+  const result = typeof payload.result === 'string' ? payload.result : '';
+  const reason = typeof payload.reason === 'string' ? payload.reason : '';
+  const taskSessionId = typeof payload.task_session_id === 'string' ? payload.task_session_id : '';
+  const depth = typeof payload.depth === 'number' ? payload.depth : null;
+
+  return (
+    <div className={`rounded-xl border px-3 py-2 ${config.borderClass} ${config.bgClass}`}>
+      <div className="mb-1 flex items-center gap-2">
+        <Icon className={`h-3.5 w-3.5 ${config.iconClass}`} />
+        <span className={`text-xs font-semibold ${config.labelClass}`}>{config.label}</span>
+        {depth !== null && (
+          <span className={`rounded px-1.5 py-0.5 text-[10px] ${config.badgeClass}`}>
+            层级 {depth}/5
+          </span>
+        )}
+      </div>
+
+      {goal && (
+        <p className="text-xs text-slate-700">
+          <span className="font-medium">目标: </span>{goal}
+        </p>
+      )}
+
+      {result && (
+        <p className={`text-xs text-slate-600 ${compact ? 'line-clamp-2' : ''}`}>
+          <span className="font-medium">结果: </span>{result}
+        </p>
+      )}
+
+      {reason && (
+        <p className="text-xs text-red-600">
+          <span className="font-medium">原因: </span>{reason}
+        </p>
+      )}
+
+      {taskSessionId && !compact && (
+        <p className="mt-1 text-[10px] text-slate-400 truncate">
+          {taskSessionId}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/rich/ToolCallBlock.tsx
+++ b/web/src/components/rich/ToolCallBlock.tsx
@@ -1,0 +1,58 @@
+import { Wrench } from 'lucide-react';
+
+import type { TapeEvent } from '../../api/types';
+import { getAgentToken } from '../../theme/agent-tokens';
+import { CollapsibleSection } from './shared/CollapsibleSection';
+import { JsonTable } from './shared/JsonTable';
+
+interface ToolCallBlockProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+export function ToolCallBlock({ event, compact = false }: ToolCallBlockProps) {
+  const payload = event.payload ?? {};
+  const reasoning = typeof payload.reasoning === 'string' ? payload.reasoning : '';
+  const toolCalls = Array.isArray(payload.tool_calls) ? payload.tool_calls as { name: string; arguments: Record<string, unknown> }[] : [];
+
+  const agentId = event.src.replace('agent:', '');
+  const token = getAgentToken(agentId);
+
+  if (toolCalls.length === 0) return null;
+
+  return (
+    <div
+      className="rounded-xl border px-3 py-2"
+      style={{ borderColor: `${token.color}40`, backgroundColor: `${token.bgColor}80` }}
+    >
+      <div className="mb-1 flex items-center gap-2">
+        <Wrench className="h-3.5 w-3.5" style={{ color: token.color }} />
+        <span className="text-xs font-semibold" style={{ color: token.color }}>
+          工具调用
+        </span>
+        <span className="text-xs text-slate-400">
+          {toolCalls.length} 个工具
+        </span>
+      </div>
+
+      {reasoning && (
+        <CollapsibleSection title="推理过程" className="mb-2">
+          <p className="whitespace-pre-wrap text-xs text-slate-600">{reasoning}</p>
+        </CollapsibleSection>
+      )}
+
+      <div className={compact ? 'space-y-1' : 'space-y-2'}>
+        {toolCalls.map((tc, i) => (
+          <div key={i} className="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5">
+            <p className="text-xs font-medium text-slate-700">{tc.name}</p>
+            {tc.arguments && Object.keys(tc.arguments).length > 0 && !compact && (
+              <div className="mt-1">
+                <JsonTable data={tc.arguments} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/rich/ToolResultBlock.tsx
+++ b/web/src/components/rich/ToolResultBlock.tsx
@@ -62,9 +62,12 @@ function renderResult(tool: string, result: string, compact: boolean) {
 
 export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps) {
   const payload = event.payload ?? {};
-  const tool = typeof payload.tool === 'string' ? payload.tool : '';
+  // Backend uses tool_name/output (react.py:185-186), old format uses tool/result
+  const tool = typeof payload.tool_name === 'string' ? payload.tool_name
+    : typeof payload.tool === 'string' ? payload.tool : '';
   const args = payload.arguments as Record<string, unknown> | undefined;
-  const result = typeof payload.result === 'string' ? payload.result : '';
+  const result = typeof payload.output === 'string' ? payload.output
+    : typeof payload.result === 'string' ? payload.result : '';
   const endsLoop = !!payload.ends_loop;
 
   const agentId = event.src.replace('agent:', '');

--- a/web/src/components/rich/ToolResultBlock.tsx
+++ b/web/src/components/rich/ToolResultBlock.tsx
@@ -1,0 +1,103 @@
+import { CheckCircle2 } from 'lucide-react';
+
+import type { TapeEvent } from '../../api/types';
+import { getAgentToken } from '../../theme/agent-tokens';
+import { JsonTable } from './shared/JsonTable';
+import { CollapsibleSection } from './shared/CollapsibleSection';
+
+interface ToolResultBlockProps {
+  event: TapeEvent;
+  compact?: boolean;
+}
+
+function tryParseJson(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderResult(tool: string, result: string, compact: boolean) {
+  const parsed = tryParseJson(result);
+
+  // Structured rendering for known tools
+  if (tool === 'query_state' && parsed) {
+    return <JsonTable data={parsed} />;
+  }
+
+  if (tool === 'query_role_map' && parsed) {
+    return <JsonTable data={parsed} />;
+  }
+
+  if (tool === 'search_memory' && parsed) {
+    const results = Array.isArray(parsed.results) ? parsed.results : [];
+    if (results.length === 0) return <p className="text-xs text-slate-500">无相关记忆</p>;
+    return (
+      <div className="space-y-1">
+        {results.map((r: { title?: string; content?: string }, i: number) => (
+          <div key={i} className="rounded border border-slate-100 bg-slate-50 px-2 py-1">
+            {r.title && <p className="text-xs font-medium text-slate-700">{r.title}</p>}
+            {r.content && !compact && (
+              <p className="text-xs text-slate-500 line-clamp-2">{r.content}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // JSON result — show as table
+  if (parsed) {
+    return <JsonTable data={parsed} />;
+  }
+
+  // Plain text result
+  if (compact && result.length > 100) {
+    return <p className="text-xs text-slate-600 line-clamp-2">{result}</p>;
+  }
+  return <p className="whitespace-pre-wrap text-xs text-slate-600">{result}</p>;
+}
+
+export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps) {
+  const payload = event.payload ?? {};
+  const tool = typeof payload.tool === 'string' ? payload.tool : '';
+  const args = payload.arguments as Record<string, unknown> | undefined;
+  const result = typeof payload.result === 'string' ? payload.result : '';
+  const endsLoop = !!payload.ends_loop;
+
+  const agentId = event.src.replace('agent:', '');
+  const token = getAgentToken(agentId);
+
+  return (
+    <div
+      className="rounded-xl border px-3 py-2"
+      style={{ borderColor: `${token.color}40`, backgroundColor: `${token.bgColor}80` }}
+    >
+      <div className="mb-1 flex items-center gap-2">
+        <CheckCircle2 className="h-3.5 w-3.5" style={{ color: token.color }} />
+        <span className="text-xs font-semibold" style={{ color: token.color }}>
+          {tool || '工具结果'}
+        </span>
+        {endsLoop && (
+          <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-700">
+            结束循环
+          </span>
+        )}
+      </div>
+
+      {args && Object.keys(args).length > 0 && !compact && (
+        <CollapsibleSection title="调用参数" className="mb-1">
+          <JsonTable data={args} />
+        </CollapsibleSection>
+      )}
+
+      {result && (
+        <div className="mt-1 rounded-lg border border-slate-100 bg-white p-2">
+          {renderResult(tool, result, compact)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/rich/shared/CollapsibleSection.tsx
+++ b/web/src/components/rich/shared/CollapsibleSection.tsx
@@ -1,0 +1,32 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+interface CollapsibleSectionProps {
+  title: string;
+  defaultOpen?: boolean;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  className = '',
+  children,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center gap-1 text-xs text-slate-500 hover:text-slate-700"
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <span>{title}</span>
+      </button>
+      {open && <div className="mt-1">{children}</div>}
+    </div>
+  );
+}

--- a/web/src/components/rich/shared/JsonTable.tsx
+++ b/web/src/components/rich/shared/JsonTable.tsx
@@ -1,0 +1,34 @@
+interface JsonTableProps {
+  data: Record<string, unknown>;
+  className?: string;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'number') {
+    return new Intl.NumberFormat('zh-CN').format(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+export function JsonTable({ data, className = '' }: JsonTableProps) {
+  const entries = Object.entries(data).filter(
+    ([, v]) => v !== undefined && v !== null && v !== '',
+  );
+  if (entries.length === 0) return null;
+
+  return (
+    <table className={`w-full text-xs ${className}`}>
+      <tbody>
+        {entries.map(([key, value]) => (
+          <tr key={key} className="border-b border-slate-100 last:border-0">
+            <td className="py-1 pr-3 font-medium text-slate-500">{key}</td>
+            <td className="py-1 text-slate-700">{formatValue(value)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/src/utils/tape.ts
+++ b/web/src/utils/tape.ts
@@ -124,8 +124,8 @@ export function extractEventText(event: TapeEvent): string {
   const message = payload.message;
   const command = payload.command;
   const description = payload.description;
-  const tool = payload.tool;
-  const result = payload.result;
+  const tool = payload.tool_name ?? payload.tool;
+  const result = payload.output ?? payload.result;
   const thought = payload.thought;
   const actions = payload.actions;
   const assistantReply = extractRespondToPlayerContent(payload);


### PR DESCRIPTION
## Summary
- Add 6 specialized block renderers for structured TapeEvent display in TAPE CONTEXT panel
- `BlockSelector` dispatches events to: `ToolCallBlock`, `ToolResultBlock`, `IncidentBlock`, `TaskSessionBlock`, `SystemNoticeBar`, `AgentMessageBlock`
- Each block renders structured payload data (JSON tables, effect formatting, status colors) instead of plain text
- Agent-to-agent messages use dashed borders with routing direction; system events use full-width notice bars
- Integrated into RightSidebar TAPE CONTEXT with compact mode; non-matched events fall back to existing rendering
- Includes design spec: `docs/design/rich-content-blocks-spec.md`

## Test plan
- [ ] Verify TAPE CONTEXT renders tool_call events as ToolCallBlock with collapsible reasoning
- [ ] Verify tool_result events show structured results (JSON tables for query_state)
- [ ] Verify incident_created events show effects with percentage formatting
- [ ] Verify task_created/finished/failed/timeout events show correct status colors
- [ ] Verify tick_completed events render as SystemNoticeBar with turn/treasury/population
- [ ] Verify agent-to-agent messages show routing direction (src > dst)
- [ ] Verify chat/response events still use default MessageBubble rendering
- [ ] Verify build passes: `npx vite build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)