### PR TITLE
feat: agent online status indicator (Phase 3)

### DIFF
--- a/packages/server/simu_server/agents/registry.py
+++ b/packages/server/simu_server/agents/registry.py
@@ -86,6 +86,20 @@ class AgentRegistry:
         await self._db.conn.commit()
 
     @staticmethod
+    def is_agent_online(agent: AgentRegistration, timeout: int) -> bool:
+        """Determine if an agent is online based on status and heartbeat recency."""
+        if agent.status not in (AgentStatus.RUNNING, AgentStatus.STARTING):
+            return False
+        hb = agent.last_heartbeat
+        if hb is None:
+            return False
+        if isinstance(hb, str):
+            hb = datetime.fromisoformat(hb)
+        if hb.tzinfo is None:
+            hb = hb.replace(tzinfo=UTC)
+        return (datetime.now(UTC) - hb).total_seconds() < timeout
+
+    @staticmethod
     def _row_to_reg(row: tuple) -> AgentRegistration:
         return AgentRegistration(
             agent_id=row[0],

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
 from typing import Any, AsyncGenerator
 
 from fastapi import FastAPI
@@ -137,6 +136,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     queue_controller.set_dispatcher(dispatch)
 
+    # Shared set tracking which agents are currently online — used by both
+    # the periodic heartbeat checker and the callback broadcast helper to
+    # avoid duplicate WebSocket broadcasts.
+    online_agents: set[str] = set()
+
     # Inject dependencies into route modules
     deps = {
         "db": db,
@@ -151,6 +155,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         "engine": engine,
         "group_store": group_store,
         "ws_manager": ws_manager,
+        "online_agents": online_agents,
     }
     client.set_dependencies(**deps)
     callback.set_dependencies(**deps)
@@ -179,31 +184,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 logger.warning("Failed to spawn agent %s", agent.agent_id, exc_info=True)
 
     # Background task: detect agents that missed heartbeat and broadcast offline
-    _online_agents: set[str] = set()
-
     async def _heartbeat_checker() -> None:
         timeout = settings.agent_heartbeat_timeout
         while True:
             await asyncio.sleep(15)
             try:
                 agents = await agent_registry.list_all()
-                now = datetime.now(UTC)
                 for agent in agents:
-                    hb = agent.last_heartbeat
-                    if isinstance(hb, str):
-                        hb = datetime.fromisoformat(hb)
-                    if hb and hb.tzinfo is None:
-                        hb = hb.replace(tzinfo=UTC)
+                    is_online = AgentRegistry.is_agent_online(agent, timeout)
+                    was_online = agent.agent_id in online_agents
 
-                    is_online = (
-                        agent.status in (AgentStatus.RUNNING, AgentStatus.STARTING)
-                        and hb is not None
-                        and (now - hb).total_seconds() < timeout
-                    )
-
-                    was_online = agent.agent_id in _online_agents
                     if is_online and not was_online:
-                        _online_agents.add(agent.agent_id)
+                        online_agents.add(agent.agent_id)
                         await ws_manager.broadcast({
                             "kind": "agent_status",
                             "data": {
@@ -214,7 +206,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                             },
                         })
                     elif not is_online and was_online:
-                        _online_agents.discard(agent.agent_id)
+                        online_agents.discard(agent.agent_id)
                         await ws_manager.broadcast({
                             "kind": "agent_status",
                             "data": {

--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 from typing import Any, AsyncGenerator
 
 from fastapi import FastAPI
@@ -176,10 +178,62 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             except Exception:
                 logger.warning("Failed to spawn agent %s", agent.agent_id, exc_info=True)
 
+    # Background task: detect agents that missed heartbeat and broadcast offline
+    _online_agents: set[str] = set()
+
+    async def _heartbeat_checker() -> None:
+        timeout = settings.agent_heartbeat_timeout
+        while True:
+            await asyncio.sleep(15)
+            try:
+                agents = await agent_registry.list_all()
+                now = datetime.now(UTC)
+                for agent in agents:
+                    hb = agent.last_heartbeat
+                    if isinstance(hb, str):
+                        hb = datetime.fromisoformat(hb)
+                    if hb and hb.tzinfo is None:
+                        hb = hb.replace(tzinfo=UTC)
+
+                    is_online = (
+                        agent.status in (AgentStatus.RUNNING, AgentStatus.STARTING)
+                        and hb is not None
+                        and (now - hb).total_seconds() < timeout
+                    )
+
+                    was_online = agent.agent_id in _online_agents
+                    if is_online and not was_online:
+                        _online_agents.add(agent.agent_id)
+                        await ws_manager.broadcast({
+                            "kind": "agent_status",
+                            "data": {
+                                "agent_id": agent.agent_id,
+                                "agent_name": agent.display_name or agent.agent_id,
+                                "status": agent.status.value,
+                                "is_online": True,
+                            },
+                        })
+                    elif not is_online and was_online:
+                        _online_agents.discard(agent.agent_id)
+                        await ws_manager.broadcast({
+                            "kind": "agent_status",
+                            "data": {
+                                "agent_id": agent.agent_id,
+                                "agent_name": agent.display_name or agent.agent_id,
+                                "status": agent.status.value,
+                                "is_online": False,
+                            },
+                        })
+            except Exception:
+                logger.debug("Heartbeat checker iteration failed", exc_info=True)
+
+    heartbeat_task = asyncio.create_task(_heartbeat_checker())
+
     logger.info("Server started on %s:%d", settings.host, settings.port)
     yield
 
     # Shutdown
+    heartbeat_task.cancel()
     await process_manager.shutdown_all()
     await db.close()
     logger.info("Server shut down")

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -110,19 +110,38 @@ async def _verify_agent(agent_id: str, token: str) -> None:
 
 
 async def _broadcast_agent_status(agent_id: str, is_online: bool) -> None:
-    """Broadcast agent online/offline status to all frontend WebSocket clients."""
+    """Broadcast agent online/offline status to all frontend WebSocket clients.
+
+    Also updates the shared ``_online_agents`` set so the periodic heartbeat
+    checker in app.py stays in sync and avoids duplicate broadcasts.
+    """
     ws_mgr = _get("ws_manager")
     if ws_mgr is None:
         return
-    registry = _get("agent_registry")
-    agent = await registry.get(agent_id) if registry else None
-    display_name = agent.display_name if agent else agent_id
+
+    # Keep _online_agents in sync with callback-driven transitions
+    online_set: set[str] | None = _get("online_agents")
+    if online_set is not None:
+        if is_online:
+            online_set.add(agent_id)
+        else:
+            online_set.discard(agent_id)
+
+    try:
+        registry = _get("agent_registry")
+        agent = await registry.get(agent_id) if registry else None
+        display_name = agent.display_name if agent else agent_id
+        status = agent.status.value if agent else "unknown"
+    except Exception:
+        display_name = agent_id
+        status = "unknown"
+
     await ws_mgr.broadcast({
         "kind": "agent_status",
         "data": {
             "agent_id": agent_id,
             "agent_name": display_name or agent_id,
-            "status": agent.status.value if agent else "unknown",
+            "status": status,
             "is_online": is_online,
         },
     })
@@ -178,7 +197,8 @@ async def report_status(
     new_status = status_map.get(req.status)
     if new_status:
         await _get("agent_registry").update_status(x_agent_id, new_status)
-        await _broadcast_agent_status(x_agent_id, is_online=False)
+        is_online = new_status in (AgentStatus.RUNNING, AgentStatus.STARTING)
+        await _broadcast_agent_status(x_agent_id, is_online=is_online)
     return {"status": "ok"}
 
 

--- a/packages/server/simu_server/routes/callback.py
+++ b/packages/server/simu_server/routes/callback.py
@@ -109,6 +109,25 @@ async def _verify_agent(agent_id: str, token: str) -> None:
         raise HTTPException(status_code=403, detail="Invalid callback token")
 
 
+async def _broadcast_agent_status(agent_id: str, is_online: bool) -> None:
+    """Broadcast agent online/offline status to all frontend WebSocket clients."""
+    ws_mgr = _get("ws_manager")
+    if ws_mgr is None:
+        return
+    registry = _get("agent_registry")
+    agent = await registry.get(agent_id) if registry else None
+    display_name = agent.display_name if agent else agent_id
+    await ws_mgr.broadcast({
+        "kind": "agent_status",
+        "data": {
+            "agent_id": agent_id,
+            "agent_name": display_name or agent_id,
+            "status": agent.status.value if agent else "unknown",
+            "is_online": is_online,
+        },
+    })
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle
 # ---------------------------------------------------------------------------
@@ -130,6 +149,7 @@ async def register_agent(
     await registry.update_capabilities(x_agent_id, req.capabilities)
     await registry.update_heartbeat(x_agent_id)
     logger.info("Agent %s registered with capabilities: %s", x_agent_id, req.capabilities)
+    await _broadcast_agent_status(x_agent_id, is_online=True)
     return {"status": "ok"}
 
 
@@ -158,6 +178,7 @@ async def report_status(
     new_status = status_map.get(req.status)
     if new_status:
         await _get("agent_registry").update_status(x_agent_id, new_status)
+        await _broadcast_agent_status(x_agent_id, is_online=False)
     return {"status": "ok"}
 
 

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -6,7 +6,6 @@ Preserves all V4 Web API functionality per design constraint.
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -21,6 +20,7 @@ from simu_shared.models import (
     RoutedMessage,
     TapeEvent,
 )
+from simu_server.agents.registry import AgentRegistry
 from simu_server.config import settings
 
 router = APIRouter(prefix="/api")
@@ -330,33 +330,19 @@ async def manual_tick() -> dict[str, Any]:
 # Agent management
 # ---------------------------------------------------------------------------
 
-def _is_agent_online(agent: AgentRegistration) -> bool:
-    """Determine if an agent is online based on status and heartbeat recency."""
-    if agent.status not in (AgentStatus.RUNNING, AgentStatus.STARTING):
-        return False
-    if agent.last_heartbeat is None:
-        return False
-    hb = agent.last_heartbeat
-    if isinstance(hb, str):
-        hb = datetime.fromisoformat(hb)
-    if hb.tzinfo is None:
-        hb = hb.replace(tzinfo=UTC)
-    elapsed = (datetime.now(UTC) - hb).total_seconds()
-    return elapsed < settings.agent_heartbeat_timeout
-
-
 @router.get("/agents")
 async def list_agents() -> list[dict[str, Any]]:
-    registry = _get("agent_registry")
+    registry: AgentRegistry | None = _get("agent_registry")
     if registry is None:
         return []
     agents = await registry.list_all()
+    timeout = settings.agent_heartbeat_timeout
     return [
         {
             "agent_id": a.agent_id,
             "agent_name": a.display_name or a.agent_id,
             "status": a.status.value,
-            "is_online": _is_agent_online(a),
+            "is_online": AgentRegistry.is_agent_online(a, timeout),
         }
         for a in agents
     ]

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -6,6 +6,7 @@ Preserves all V4 Web API functionality per design constraint.
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -20,6 +21,7 @@ from simu_shared.models import (
     RoutedMessage,
     TapeEvent,
 )
+from simu_server.config import settings
 
 router = APIRouter(prefix="/api")
 
@@ -328,6 +330,21 @@ async def manual_tick() -> dict[str, Any]:
 # Agent management
 # ---------------------------------------------------------------------------
 
+def _is_agent_online(agent: AgentRegistration) -> bool:
+    """Determine if an agent is online based on status and heartbeat recency."""
+    if agent.status not in (AgentStatus.RUNNING, AgentStatus.STARTING):
+        return False
+    if agent.last_heartbeat is None:
+        return False
+    hb = agent.last_heartbeat
+    if isinstance(hb, str):
+        hb = datetime.fromisoformat(hb)
+    if hb.tzinfo is None:
+        hb = hb.replace(tzinfo=UTC)
+    elapsed = (datetime.now(UTC) - hb).total_seconds()
+    return elapsed < settings.agent_heartbeat_timeout
+
+
 @router.get("/agents")
 async def list_agents() -> list[dict[str, Any]]:
     registry = _get("agent_registry")
@@ -338,6 +355,8 @@ async def list_agents() -> list[dict[str, Any]]:
         {
             "agent_id": a.agent_id,
             "agent_name": a.display_name or a.agent_id,
+            "status": a.status.value,
+            "is_online": _is_agent_online(a),
         }
         for a in agents
     ]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { createGameClient } from './api/client';
 import type {
+  AgentStatusData,
   ChatData,
   CurrentTapeResponse,
   GroupChat,
@@ -211,6 +212,14 @@ export default function App() {
       }
 
       const agents = await client.current.getAgents().catch(() => []);
+
+      // Extract agent online statuses from REST response
+      const statuses: Record<string, boolean> = {};
+      for (const a of agents) {
+        statuses[a.agent_id] = a.is_online ?? false;
+      }
+      agentStore.getState().setAgentStatuses(statuses);
+
       let groupedSessions = sessionsData.agent_sessions || [];
       if (groupedSessions.length === 0) {
         groupedSessions = buildGroupsFromFlatSessions(sessionsData.sessions || []);
@@ -424,10 +433,16 @@ export default function App() {
       );
     });
 
+    const offAgentStatus = client.current.on<AgentStatusData>('agent_status', (data) => {
+      if (!data || !data.agent_id) return;
+      agentStore.getState().setAgentStatus(data.agent_id, data.is_online);
+    });
+
     return () => {
       offChat();
       offState();
       offSessionState();
+      offAgentStatus();
     };
   }, [refreshChatTape, refreshViewTape]);
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -54,7 +54,7 @@ export class GameClient {
     this.messageHandlers = new Map();
     this.connectionStateListeners = new Set();
 
-    const messageKinds: WSMessageKind[] = ['chat', 'state', 'event', 'error', 'session_state'];
+    const messageKinds: WSMessageKind[] = ['chat', 'state', 'event', 'error', 'session_state', 'agent_status'];
     messageKinds.forEach((kind) => {
       this.messageHandlers.set(kind, new Set());
     });

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2,7 +2,7 @@
  * WebSocket 消息类型定义
  */
 
-export type WSMessageKind = 'chat' | 'state' | 'event' | 'error' | 'session_state';
+export type WSMessageKind = 'chat' | 'state' | 'event' | 'error' | 'session_state' | 'agent_status';
 
 export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
 
@@ -86,6 +86,15 @@ export interface HealthResponse {
 export interface AgentInfo {
   agent_id: string;
   agent_name: string;
+  status?: string;
+  is_online?: boolean;
+}
+
+export interface AgentStatusData {
+  agent_id: string;
+  agent_name: string;
+  status: string;
+  is_online: boolean;
 }
 
 export type AgentsResponse = AgentInfo[];

--- a/web/src/components/layout/LeftSidebar.tsx
+++ b/web/src/components/layout/LeftSidebar.tsx
@@ -44,6 +44,7 @@ export function LeftSidebar({
   const creatingAgentId = useAgentStore((s) => s.creatingAgentId);
   const groupChats = useAgentStore((s) => s.groupChats);
   const currentGroupId = useAgentStore((s) => s.currentGroupId);
+  const agentStatuses = useAgentStore((s) => s.agentStatuses);
   const toggleAgent = useAgentStore((s) => s.toggleAgent);
 
   const [leftPanelSplit, setLeftPanelSplit] = useState(50);
@@ -120,6 +121,14 @@ export function LeftSidebar({
                       ) : (
                         <ChevronRight className="h-3.5 w-3.5 text-slate-500" />
                       )}
+                      <span
+                        className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${
+                          agentStatuses[group.agent_id]
+                            ? 'bg-emerald-500'
+                            : 'bg-slate-300'
+                        }`}
+                        title={agentStatuses[group.agent_id] ? '在线' : '离线'}
+                      />
                       <p className="truncate text-xs font-semibold text-slate-700">
                         {group.agent_name}
                       </p>

--- a/web/src/stores/agentStore.ts
+++ b/web/src/stores/agentStore.ts
@@ -20,10 +20,13 @@ interface AgentState {
   selectedViewSessionId: string | null;
   showSubSessions: boolean;
   loadingSubSessions: boolean;
+  agentStatuses: Record<string, boolean>;
   creatingAgentId: string | null;
   loading: boolean;
   error: string | null;
 
+  setAgentStatus: (agentId: string, isOnline: boolean) => void;
+  setAgentStatuses: (statuses: Record<string, boolean>) => void;
   setAgentSessions: (agentSessions: AgentSessionGroup[]) => void;
   setSessions: (sessions: SessionInfo[]) => void;
   setCurrentAgentId: (id: string) => void;
@@ -58,10 +61,16 @@ export const useAgentStore = create<AgentState>((set) => ({
   selectedViewSessionId: null,
   showSubSessions: false,
   loadingSubSessions: false,
+  agentStatuses: {},
   creatingAgentId: null,
   loading: false,
   error: null,
 
+  setAgentStatus: (agentId, isOnline) =>
+    set((state) => ({
+      agentStatuses: { ...state.agentStatuses, [agentId]: isOnline },
+    })),
+  setAgentStatuses: (statuses) => set({ agentStatuses: statuses }),
   setAgentSessions: (agentSessions) => set({ agentSessions }),
   setSessions: (sessions) => set({ sessions }),
   setCurrentAgentId: (currentAgentId) => set({ currentAgentId }),


### PR DESCRIPTION
## Summary
- **Backend**: `/api/agents` now returns `status` and `is_online` fields (computed from heartbeat recency vs `agent_heartbeat_timeout`). WebSocket broadcasts `agent_status` messages on agent register/status changes. Background task checks heartbeat timeouts every 15s and broadcasts transitions.
- **Frontend**: Green/grey dots in LeftSidebar next to each agent name. Real-time updates via WebSocket `agent_status` handler + polling fallback through existing 6s `refreshData` cycle. New `agentStatuses` map in Zustand `agentStore`.

## Files changed (8)
| File | Change |
|------|--------|
| `packages/server/simu_server/routes/client.py` | `_is_agent_online()` helper, extended `/api/agents` response |
| `packages/server/simu_server/routes/callback.py` | `_broadcast_agent_status()` called on register + status change |
| `packages/server/simu_server/app.py` | Periodic `_heartbeat_checker` background task (15s) |
| `web/src/api/types.ts` | `agent_status` WSMessageKind, `AgentStatusData`, extended `AgentInfo` |
| `web/src/api/client.ts` | Register `agent_status` message handler |
| `web/src/stores/agentStore.ts` | `agentStatuses` state + setters |
| `web/src/App.tsx` | Populate from REST, wire WebSocket handler |
| `web/src/components/layout/LeftSidebar.tsx` | Green/grey status dot per agent |

## Test plan
- [ ] Start server + agents, verify green dots appear in sidebar
- [ ] Stop an agent process, verify dot turns grey within ~15s
- [ ] Check `/api/agents` returns `is_online: true` for running agents
- [ ] Verify no TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)