### PR TITLE
feat: Phase 3 CSS design tokens + dark mode

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import { buildGroupsFromFlatSessions, mergeAgentGroups } from './utils/sessions'
 import { LeftSidebar } from './components/layout/LeftSidebar';
 import { ChatPanel } from './components/chat/ChatPanel';
 import { RightSidebar } from './components/layout/RightSidebar';
+import { ThemeToggle } from './components/layout/ThemeToggle';
 
 export default function App() {
   const client = useRef(
@@ -673,8 +674,8 @@ export default function App() {
 
   // ── Render ─────────────────────────────────────────────────────────
   return (
-    <div className="min-h-screen bg-[#ededf0] p-3 text-slate-800">
-      <div className="flex h-[calc(100vh-1.5rem)] flex-col gap-3 overflow-hidden rounded-3xl bg-[#e4e5e9] p-3 lg:flex-row">
+    <div className="min-h-screen p-3" style={{ backgroundColor: 'var(--color-app-bg)', color: 'var(--color-text)' }}>
+      <div className="flex h-[calc(100vh-1.5rem)] flex-col gap-3 overflow-hidden rounded-3xl p-3 lg:flex-row" style={{ backgroundColor: 'var(--color-app-shell)' }}>
         <LeftSidebar
           onCreateSession={handleCreateSession}
           onSelectSession={handleSelectSession}
@@ -695,14 +696,16 @@ export default function App() {
         />
       </div>
 
+      <ThemeToggle />
+
       {loading && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 mx-auto w-fit rounded-full bg-slate-800 px-4 py-2 text-xs text-white">
+        <div className="pointer-events-none fixed inset-x-0 bottom-5 mx-auto w-fit rounded-full px-4 py-2 text-xs" style={{ backgroundColor: 'var(--color-toast-bg)', color: 'var(--color-toast-text)' }}>
           正在加载界面数据...
         </div>
       )}
 
       {error && (
-        <div className="fixed inset-x-0 bottom-5 mx-auto w-fit rounded-full bg-red-600 px-4 py-2 text-xs text-white shadow-lg">
+        <div className="fixed inset-x-0 bottom-5 mx-auto w-fit rounded-full px-4 py-2 text-xs shadow-lg" style={{ backgroundColor: 'var(--color-toast-error-bg)', color: 'var(--color-toast-text)' }}>
           {error}
         </div>
       )}

--- a/web/src/components/agents/AddAgentDialog.tsx
+++ b/web/src/components/agents/AddAgentDialog.tsx
@@ -49,15 +49,23 @@ export function AddAgentDialog({ onClose, onAddAgent }: AddAgentDialogProps) {
     }
   };
 
+  const inputStyle = {
+    borderWidth: 1,
+    borderColor: 'var(--color-border)',
+    borderStyle: 'solid' as const,
+    backgroundColor: 'var(--color-surface)',
+    color: 'var(--color-text)',
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ backgroundColor: 'var(--color-overlay)' }}>
+      <div className="w-full max-w-md rounded-xl p-6 shadow-xl" style={{ backgroundColor: 'var(--color-surface)' }}>
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-lg font-semibold">新增官员</h3>
+          <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text)' }}>新增官员</h3>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md p-1 hover:bg-slate-100"
+            className="rounded-md p-1 hover:opacity-80"
           >
             <X className="h-4 w-4" />
           </button>
@@ -65,85 +73,91 @@ export function AddAgentDialog({ onClose, onAddAgent }: AddAgentDialogProps) {
 
         <div className="mb-3 space-y-3">
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              Agent ID <span className="text-red-500">*</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              Agent ID <span style={{ color: 'var(--color-danger)' }}>*</span>
             </label>
             <input
               type="text"
               value={form.agent_id}
               onChange={(e) => setForm((prev) => ({ ...prev, agent_id: e.target.value }))}
               placeholder="如: governor_xinjiang"
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+              style={inputStyle}
             />
-            <p className="mt-1 text-[10px] text-slate-500">
+            <p className="mt-1 text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
               唯一标识符，只能包含小写字母、数字和下划线
             </p>
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              官职 <span className="text-red-500">*</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              官职 <span style={{ color: 'var(--color-danger)' }}>*</span>
             </label>
             <input
               type="text"
               value={form.title}
               onChange={(e) => setForm((prev) => ({ ...prev, title: e.target.value }))}
               placeholder="如: 新疆巡抚"
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+              style={inputStyle}
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              姓名 <span className="text-red-500">*</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              姓名 <span style={{ color: 'var(--color-danger)' }}>*</span>
             </label>
             <input
               type="text"
               value={form.name}
               onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
               placeholder="如: 左宗棠"
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+              style={inputStyle}
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              职责 <span className="text-red-500">*</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              职责 <span style={{ color: 'var(--color-danger)' }}>*</span>
             </label>
             <textarea
               value={form.duty}
               onChange={(e) => setForm((prev) => ({ ...prev, duty: e.target.value }))}
               placeholder="如: 新疆省民政、农桑、商贸、边防"
               rows={2}
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none resize-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none resize-none"
+              style={inputStyle}
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              为人 <span className="text-red-500">*</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              为人 <span style={{ color: 'var(--color-danger)' }}>*</span>
             </label>
             <textarea
               value={form.personality}
               onChange={(e) => setForm((prev) => ({ ...prev, personality: e.target.value }))}
               placeholder="如: 办事干练，忠心耿耿，深得朝廷信任"
               rows={2}
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none resize-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none resize-none"
+              style={inputStyle}
             />
           </div>
 
           <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              管辖省份 <span className="text-slate-400">(可选)</span>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>
+              管辖省份 <span style={{ color: 'var(--color-text-muted)' }}>(可选)</span>
             </label>
             <input
               type="text"
               value={form.province}
               onChange={(e) => setForm((prev) => ({ ...prev, province: e.target.value }))}
               placeholder="如: xinjiang，留空表示全国"
-              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none"
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+              style={inputStyle}
             />
-            <p className="mt-1 text-[10px] text-slate-500">
+            <p className="mt-1 text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
               省份的英文标识，如 zhili, fujian 等
             </p>
           </div>
@@ -151,11 +165,13 @@ export function AddAgentDialog({ onClose, onAddAgent }: AddAgentDialogProps) {
 
         {error && (
           <div
-            className={`mb-4 rounded-lg px-3 py-2 text-xs ${
-              error.includes('失败') || error.includes('超时')
-                ? 'bg-red-50 text-red-600'
-                : 'bg-blue-50 text-blue-600'
-            }`}
+            className="mb-4 rounded-lg px-3 py-2 text-xs"
+            style={{
+              backgroundColor: error.includes('失败') || error.includes('超时')
+                ? 'var(--color-danger-soft)' : 'var(--color-info-soft)',
+              color: error.includes('失败') || error.includes('超时')
+                ? 'var(--color-danger)' : 'var(--color-info-text)',
+            }}
           >
             {error}
           </div>
@@ -165,7 +181,8 @@ export function AddAgentDialog({ onClose, onAddAgent }: AddAgentDialogProps) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg border border-slate-200 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
+            className="rounded-lg px-4 py-2 text-sm hover:opacity-80"
+            style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', color: 'var(--color-text)' }}
           >
             取消
           </button>
@@ -173,7 +190,8 @@ export function AddAgentDialog({ onClose, onAddAgent }: AddAgentDialogProps) {
             type="button"
             onClick={handleSubmit}
             disabled={adding}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+            className="rounded-lg px-4 py-2 text-sm disabled:opacity-50 flex items-center gap-2"
+            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-text-inverse)' }}
           >
             {adding && <Loader2 className="h-4 w-4 animate-spin" />}
             {adding ? '生成中...' : '确定'}

--- a/web/src/components/agents/CreateGroupDialog.tsx
+++ b/web/src/components/agents/CreateGroupDialog.tsx
@@ -19,24 +19,25 @@ export function CreateGroupDialog({ onClose, onCreateGroup }: CreateGroupDialogP
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-        <h3 className="mb-4 text-lg font-semibold">创建群聊</h3>
+    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ backgroundColor: 'var(--color-overlay)' }}>
+      <div className="w-full max-w-md rounded-xl p-6 shadow-xl" style={{ backgroundColor: 'var(--color-surface)' }}>
+        <h3 className="mb-4 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>创建群聊</h3>
         <div className="mb-4">
-          <label className="mb-1 block text-sm font-medium text-slate-700">群聊名称</label>
+          <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>群聊名称</label>
           <input
             type="text"
             value={newGroupName}
             onChange={(e) => setNewGroupName(e.target.value)}
             placeholder="输入群聊名称"
-            className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-300 focus:outline-none"
+            className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+            style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)', color: 'var(--color-text)' }}
           />
         </div>
         <div className="mb-4">
-          <label className="mb-2 block text-sm font-medium text-slate-700">选择成员</label>
+          <label className="mb-2 block text-sm font-medium" style={{ color: 'var(--color-text)' }}>选择成员</label>
           <div className="max-h-48 space-y-2 overflow-y-auto">
             {agentSessions.map((group) => (
-              <div key={group.agent_id} className="rounded-lg border border-slate-200 p-2">
+              <div key={group.agent_id} className="rounded-lg p-2" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid' }}>
                 <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
@@ -52,15 +53,15 @@ export function CreateGroupDialog({ onClose, onCreateGroup }: CreateGroupDialogP
                         });
                       }
                     }}
-                    className="rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="rounded"
                   />
-                  <span className="text-sm text-slate-700">{group.agent_name}</span>
+                  <span className="text-sm" style={{ color: 'var(--color-text)' }}>{group.agent_name}</span>
                 </label>
               </div>
             ))}
           </div>
           {selectedAgents.size > 0 && (
-            <div className="mt-2 text-xs text-slate-500">
+            <div className="mt-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
               已选择: {Array.from(selectedAgents).join(', ')}
             </div>
           )}
@@ -69,7 +70,8 @@ export function CreateGroupDialog({ onClose, onCreateGroup }: CreateGroupDialogP
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg border border-slate-200 px-4 py-2 text-sm text-slate-700 hover:bg-slate-50"
+            className="rounded-lg px-4 py-2 text-sm hover:opacity-80"
+            style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', color: 'var(--color-text)' }}
           >
             取消
           </button>
@@ -77,7 +79,8 @@ export function CreateGroupDialog({ onClose, onCreateGroup }: CreateGroupDialogP
             type="button"
             onClick={handleCreate}
             disabled={!newGroupName.trim() || selectedAgents.size === 0}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+            className="rounded-lg px-4 py-2 text-sm disabled:opacity-50"
+            style={{ backgroundColor: 'var(--color-primary)', color: 'var(--color-text-inverse)' }}
           >
             创建
           </button>

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -44,9 +44,9 @@ export function ChatInput({ isValidSession, onSend, onSendToGroup }: ChatInputPr
         : '输入消息，Enter 发送...';
 
   return (
-    <div className="border-t border-slate-200 p-4">
+    <div className="p-4" style={{ borderTopWidth: 1, borderTopColor: 'var(--color-border)', borderTopStyle: 'solid' }}>
       {currentGroupId && (
-        <div className="mb-2 flex items-center gap-2 rounded-lg bg-purple-50 px-3 py-1.5 text-sm text-purple-700">
+        <div className="mb-2 flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm" style={{ backgroundColor: 'var(--color-accent-soft)', color: 'var(--color-accent-text)' }}>
           <Users className="h-4 w-4" />
           <span>群聊模式：消息将发送给所有成员</span>
         </div>
@@ -58,15 +58,24 @@ export function ChatInput({ isValidSession, onSend, onSendToGroup }: ChatInputPr
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={sending || (!currentGroupId && !isValidSession)}
-          className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm outline-none focus:border-blue-300 disabled:opacity-60"
+          className="flex-1 rounded-xl px-3 py-2 text-sm outline-none disabled:opacity-60"
+          style={{
+            borderWidth: 1,
+            borderColor: 'var(--color-border)',
+            borderStyle: 'solid',
+            backgroundColor: 'var(--color-surface-alt)',
+            color: 'var(--color-text)',
+          }}
         />
         <button
           type="button"
           onClick={handleClick}
           disabled={sending || !inputText.trim() || (!currentGroupId && !isValidSession)}
-          className={`rounded-xl px-3 py-2 text-white hover:opacity-90 disabled:opacity-60 ${
-            currentGroupId ? 'bg-purple-600 hover:bg-purple-700' : 'bg-blue-600 hover:bg-blue-700'
-          }`}
+          className="rounded-xl px-3 py-2 hover:opacity-90 disabled:opacity-60"
+          style={{
+            backgroundColor: currentGroupId ? 'var(--color-accent)' : 'var(--color-primary)',
+            color: 'var(--color-text-inverse)',
+          }}
         >
           <Send className="h-4 w-4" />
         </button>

--- a/web/src/components/chat/ChatPanel.tsx
+++ b/web/src/components/chat/ChatPanel.tsx
@@ -46,15 +46,17 @@ export function ChatPanel({ onSend, onSendToGroup }: ChatPanelProps) {
       : (currentSession?.title ?? `${currentAgentId} - 对话`);
 
   return (
-    <main className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white">
-      <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+    <main className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
+      <div className="flex items-center justify-between px-5 py-4" style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }}>
         <div className="min-w-0">
-          <p className="truncate text-xl font-semibold">{headerTitle}</p>
+          <p className="truncate text-xl font-semibold" style={{ color: 'var(--color-text)' }}>{headerTitle}</p>
         </div>
         <div
-          className={`rounded-full px-3 py-1 text-xs font-semibold ${
-            isValidSession ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
-          }`}
+          className="rounded-full px-3 py-1 text-xs font-semibold"
+          style={{
+            backgroundColor: isValidSession ? 'var(--color-success-badge-bg)' : 'var(--color-warning-badge-bg)',
+            color: isValidSession ? 'var(--color-success-text)' : 'var(--color-warning-text)',
+          }}
         >
           {isValidSession ? 'Online' : '未选择会话'}
         </div>
@@ -63,17 +65,17 @@ export function ChatPanel({ onSend, onSendToGroup }: ChatPanelProps) {
       <div className="flex-1 overflow-y-auto p-5">
         {!isValidSession ? (
           <div className="flex h-full items-center justify-center">
-            <div className="rounded-2xl border border-amber-200 bg-amber-50 p-8 text-center">
-              <MessageSquare className="mx-auto mb-4 h-12 w-12 text-amber-500" />
-              <h3 className="mb-2 text-lg font-semibold text-amber-800">请先选择或创建会话</h3>
-              <p className="text-sm text-amber-700">
+            <div className="rounded-2xl p-8 text-center" style={{ borderWidth: 1, borderColor: 'var(--color-warning-border)', borderStyle: 'solid', backgroundColor: 'var(--color-warning-soft)' }}>
+              <MessageSquare className="mx-auto mb-4 h-12 w-12" style={{ color: 'var(--color-warning-icon)' }} />
+              <h3 className="mb-2 text-lg font-semibold" style={{ color: 'var(--color-warning-strong)' }}>请先选择或创建会话</h3>
+              <p className="text-sm" style={{ color: 'var(--color-warning-text)' }}>
                 在左侧列表中选择一个现有会话，或点击{' '}
                 <Plus className="inline h-4 w-4" /> 按钮创建新会话。
               </p>
             </div>
           </div>
         ) : chatMessages.length === 0 ? (
-          <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6 text-sm text-slate-500">
+          <div className="rounded-2xl p-6 text-sm" style={{ borderWidth: 1, borderColor: 'var(--color-border-strong)', borderStyle: 'dashed', backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text-secondary)' }}>
             {pendingSession
               ? '输入内容即可创建新会话并开始对话。'
               : '当前会话暂无消息，输入内容即可开始对话。'}
@@ -90,12 +92,12 @@ export function ChatPanel({ onSend, onSendToGroup }: ChatPanelProps) {
 
             {responseTimeoutError && (
               <div className="flex justify-center">
-                <div className="max-w-[80%] rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                <div className="max-w-[80%] rounded-2xl px-4 py-3" style={{ borderWidth: 1, borderColor: 'var(--color-danger-border)', borderStyle: 'solid', backgroundColor: 'var(--color-danger-soft)', color: 'var(--color-danger-text)' }}>
                   <div className="flex items-start gap-2">
                     <span className="text-lg">⚠️</span>
                     <div>
                       <p className="text-sm font-medium">Agent 响应超时</p>
-                      <p className="mt-1 text-xs text-red-600">{responseTimeoutError}</p>
+                      <p className="mt-1 text-xs" style={{ color: 'var(--color-danger)' }}>{responseTimeoutError}</p>
                     </div>
                   </div>
                 </div>

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -3,16 +3,18 @@ import { formatDate } from '../../utils/format';
 import { renderMarkdown } from '../../utils/render';
 import { extractEventText, isPlayerMessage } from '../../utils/tape';
 import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
+import { useThemeStore } from '../../theme/useTheme';
 
 interface MessageBubbleProps {
   event: TapeEvent;
 }
 
 export function MessageBubble({ event }: MessageBubbleProps) {
+  const theme = useThemeStore((s) => s.theme);
   const isPlayer = isPlayerMessage(event.src);
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(isPlayer ? 'player' : agentId);
-  const colors = getActiveColors(token);
+  const colors = getActiveColors(token, theme);
 
   if (isPlayer) {
     return (

--- a/web/src/components/chat/MessageBubble.tsx
+++ b/web/src/components/chat/MessageBubble.tsx
@@ -2,7 +2,7 @@ import type { TapeEvent } from '../../api/types';
 import { formatDate } from '../../utils/format';
 import { renderMarkdown } from '../../utils/render';
 import { extractEventText, isPlayerMessage } from '../../utils/tape';
-import { getAgentToken } from '../../theme/agent-tokens';
+import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
 
 interface MessageBubbleProps {
   event: TapeEvent;
@@ -12,12 +12,13 @@ export function MessageBubble({ event }: MessageBubbleProps) {
   const isPlayer = isPlayerMessage(event.src);
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(isPlayer ? 'player' : agentId);
+  const colors = getActiveColors(token);
 
   if (isPlayer) {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[75%] rounded-2xl bg-blue-600 px-4 py-3 text-white">
-          <p className="text-xs text-blue-100">
+        <div className="max-w-[75%] rounded-2xl px-4 py-3" style={{ backgroundColor: 'var(--color-player-bubble)', color: 'var(--color-text-inverse)' }}>
+          <p className="text-xs" style={{ color: 'var(--color-player-meta)' }}>
             {token.icon} {token.displayName} · {formatDate(event.timestamp)}
           </p>
           {renderMarkdown(extractEventText(event), true)}
@@ -31,13 +32,13 @@ export function MessageBubble({ event }: MessageBubbleProps) {
       <div
         className="max-w-[75%] rounded-2xl px-4 py-3"
         style={{
-          backgroundColor: token.bgColor,
+          backgroundColor: colors.bgColor,
           borderWidth: 1,
-          borderColor: token.borderColor,
+          borderColor: colors.borderColor,
           borderStyle: 'solid',
         }}
       >
-        <p className="text-xs" style={{ color: token.color }}>
+        <p className="text-xs" style={{ color: colors.color }}>
           {token.icon} {token.displayName} · {formatDate(event.timestamp)}
         </p>
         {renderMarkdown(extractEventText(event), false)}

--- a/web/src/components/chat/TypingIndicator.tsx
+++ b/web/src/components/chat/TypingIndicator.tsx
@@ -5,17 +5,17 @@ interface TypingIndicatorProps {
 export function TypingIndicator({ agentName }: TypingIndicatorProps) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[55%] rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-slate-700">
-        <p className="text-xs text-slate-500">{agentName} · 输入中...</p>
+      <div className="max-w-[55%] rounded-2xl px-4 py-3" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text)' }}>
+        <p className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>{agentName} · 输入中...</p>
         <div className="mt-2 flex items-center gap-1.5">
-          <span className="h-2 w-2 animate-pulse rounded-full bg-slate-400" />
+          <span className="h-2 w-2 animate-pulse rounded-full" style={{ backgroundColor: 'var(--color-text-muted)' }} />
           <span
-            className="h-2 w-2 animate-pulse rounded-full bg-slate-400"
-            style={{ animationDelay: '120ms' }}
+            className="h-2 w-2 animate-pulse rounded-full"
+            style={{ backgroundColor: 'var(--color-text-muted)', animationDelay: '120ms' }}
           />
           <span
-            className="h-2 w-2 animate-pulse rounded-full bg-slate-400"
-            style={{ animationDelay: '240ms' }}
+            className="h-2 w-2 animate-pulse rounded-full"
+            style={{ backgroundColor: 'var(--color-text-muted)', animationDelay: '240ms' }}
           />
         </div>
       </div>

--- a/web/src/components/empire/DeltaValue.tsx
+++ b/web/src/components/empire/DeltaValue.tsx
@@ -22,7 +22,7 @@ export function DeltaValue({ value, delta, format = true }: DeltaValueProps) {
     const formattedDelta = format ? formatNumber(Math.round(deltaNum)) : String(deltaNum);
     return (
       <span>
-        {displayValue} <span className="text-green-600">(+{formattedDelta})</span>
+        {displayValue} <span style={{ color: 'var(--color-delta-positive)' }}>(+{formattedDelta})</span>
       </span>
     );
   }
@@ -32,7 +32,7 @@ export function DeltaValue({ value, delta, format = true }: DeltaValueProps) {
     : String(Math.abs(deltaNum));
   return (
     <span>
-      {displayValue} <span className="text-red-600">(-{formattedDelta})</span>
+      {displayValue} <span style={{ color: 'var(--color-delta-negative)' }}>(-{formattedDelta})</span>
     </span>
   );
 }

--- a/web/src/components/empire/IncidentDetailDialog.tsx
+++ b/web/src/components/empire/IncidentDetailDialog.tsx
@@ -8,45 +8,48 @@ interface IncidentDetailDialogProps {
 export function IncidentDetailDialog({ incident, onClose }: IncidentDetailDialogProps) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'var(--color-overlay)' }}
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+        className="w-full max-w-md rounded-2xl p-6 shadow-xl"
+        style={{ backgroundColor: 'var(--color-surface)' }}
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">
-          <h3 className="text-lg font-semibold text-slate-900">{incident.title}</h3>
+          <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text)' }}>{incident.title}</h3>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+            className="rounded-lg p-1 hover:opacity-80"
+            style={{ color: 'var(--color-text-muted)' }}
           >
             ✕
           </button>
         </div>
         <div className="space-y-3 text-sm">
           <div>
-            <span className="text-slate-500">来源：</span>
-            <span className="text-slate-900">{incident.source}</span>
+            <span style={{ color: 'var(--color-text-secondary)' }}>来源：</span>
+            <span style={{ color: 'var(--color-text)' }}>{incident.source}</span>
           </div>
           <div>
-            <span className="text-slate-500">剩余时间：</span>
-            <span className="text-slate-900">{incident.remaining_ticks} 周</span>
+            <span style={{ color: 'var(--color-text-secondary)' }}>剩余时间：</span>
+            <span style={{ color: 'var(--color-text)' }}>{incident.remaining_ticks} 周</span>
           </div>
           <div>
-            <span className="text-slate-500">描述：</span>
-            <p className="mt-1 text-slate-900">{incident.description}</p>
+            <span style={{ color: 'var(--color-text-secondary)' }}>描述：</span>
+            <p className="mt-1" style={{ color: 'var(--color-text)' }}>{incident.description}</p>
           </div>
           {incident.effects.length > 0 && (
             <div>
-              <span className="text-slate-500">影响：</span>
+              <span style={{ color: 'var(--color-text-secondary)' }}>影响：</span>
               <div className="mt-2 space-y-1">
                 {incident.effects.map((effect, idx) => (
-                  <div key={idx} className="rounded bg-slate-50 p-2 text-xs">
-                    <div className="font-mono text-slate-700">{effect.target_path}</div>
-                    {effect.add && <div className="text-blue-600">+{effect.add}</div>}
-                    {effect.factor && <div className="text-green-600">×{effect.factor}</div>}
+                  <div key={idx} className="rounded p-2 text-xs" style={{ backgroundColor: 'var(--color-surface-alt)' }}>
+                    <div className="font-mono" style={{ color: 'var(--color-text)' }}>{effect.target_path}</div>
+                    {effect.add && <div style={{ color: 'var(--color-info-text)' }}>+{effect.add}</div>}
+                    {effect.factor && <div style={{ color: 'var(--color-delta-positive)' }}>×{effect.factor}</div>}
                   </div>
                 ))}
               </div>

--- a/web/src/components/empire/IncidentEffect.tsx
+++ b/web/src/components/empire/IncidentEffect.tsx
@@ -15,14 +15,14 @@ export function IncidentEffect({ value, incidentEffect }: IncidentEffectProps) {
   if (effectValue > 0) {
     return (
       <span>
-        {value.toFixed(2)}% <span className="text-green-600">+{absEffect.toFixed(2)}%</span>
+        {value.toFixed(2)}% <span style={{ color: 'var(--color-delta-positive)' }}>+{absEffect.toFixed(2)}%</span>
       </span>
     );
   }
 
   return (
     <span>
-      {value.toFixed(2)}% <span className="text-red-600">-{absEffect.toFixed(2)}%</span>
+      {value.toFixed(2)}% <span style={{ color: 'var(--color-delta-negative)' }}>-{absEffect.toFixed(2)}%</span>
     </span>
   );
 }

--- a/web/src/components/empire/IncidentPanel.tsx
+++ b/web/src/components/empire/IncidentPanel.tsx
@@ -8,7 +8,7 @@ export function IncidentPanel() {
   return (
     <div className="space-y-3 p-4 h-full overflow-y-auto">
       {incidents.length === 0 ? (
-        <div className="rounded-xl border border-slate-200 bg-slate-50 p-6 text-center text-slate-500">
+        <div className="rounded-xl p-6 text-center" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text-secondary)' }}>
           <p>当前无大事发生</p>
         </div>
       ) : (
@@ -16,14 +16,15 @@ export function IncidentPanel() {
           <div
             key={incident.incident_id}
             onClick={() => setSelectedIncident(incident)}
-            className="cursor-pointer rounded-xl border border-red-100 bg-red-50 p-3 transition-colors hover:border-red-200 hover:bg-red-100"
+            className="cursor-pointer rounded-xl p-3 transition-colors hover:opacity-90"
+            style={{ borderWidth: 1, borderColor: 'var(--color-danger-border)', borderStyle: 'solid', backgroundColor: 'var(--color-danger-soft)' }}
           >
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <ClipboardList className="h-4 w-4 text-red-600" />
-                <span className="text-sm font-medium text-red-900">{incident.title}</span>
+                <ClipboardList className="h-4 w-4" style={{ color: 'var(--color-danger)' }} />
+                <span className="text-sm font-medium" style={{ color: 'var(--color-text)' }}>{incident.title}</span>
               </div>
-              <div className="flex items-center gap-2 text-xs text-slate-500">
+              <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
                 <span>{incident.remaining_ticks} 周</span>
                 <span>→</span>
               </div>

--- a/web/src/components/empire/OverviewPanel.tsx
+++ b/web/src/components/empire/OverviewPanel.tsx
@@ -8,33 +8,33 @@ export function OverviewPanel() {
 
   return (
     <div className="space-y-3 p-4 h-full overflow-y-auto">
-      <div className="rounded-xl border border-amber-100 bg-amber-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-amber-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-warning-border)', borderStyle: 'solid', backgroundColor: 'var(--color-warning-soft)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-warning-text)' }}>
           <Coins className="h-4 w-4" />
           <span>国库资金</span>
         </div>
-        <p className="mt-2 text-xl font-semibold">
+        <p className="mt-2 text-xl font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={overview.treasury} delta={overview.treasury_delta} format={true} /> 两
         </p>
       </div>
 
-      <div className="rounded-xl border border-blue-100 bg-blue-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-blue-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-info-border)', borderStyle: 'solid', backgroundColor: 'var(--color-info-soft)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-info-text)' }}>
           <Users className="h-4 w-4" />
           <span>全国人口</span>
         </div>
-        <p className="mt-2 text-xl font-semibold">
+        <p className="mt-2 text-xl font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={overview.population} delta={overview.population_delta} format={true} />{' '}
           人
         </p>
       </div>
 
-      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-slate-500">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
           <MapPin className="h-4 w-4" />
           <span>省份数量</span>
         </div>
-        <p className="mt-2 text-xl font-semibold">{overview.province_count} 个</p>
+        <p className="mt-2 text-xl font-semibold" style={{ color: 'var(--color-text)' }}>{overview.province_count} 个</p>
       </div>
     </div>
   );

--- a/web/src/components/empire/ProvincePanel.tsx
+++ b/web/src/components/empire/ProvincePanel.tsx
@@ -14,7 +14,8 @@ export function ProvincePanel() {
         <select
           value={selectedProvinceId}
           onChange={(e) => setSelectedProvinceId(e.target.value)}
-          className="w-full appearance-none rounded-lg border border-slate-200 bg-white px-3 py-2 pr-8 text-sm focus:border-blue-300 focus:outline-none"
+          className="w-full appearance-none rounded-lg px-3 py-2 pr-8 text-sm focus:outline-none"
+          style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)', color: 'var(--color-text)' }}
         >
           {fullState?.provinces &&
             Object.entries(fullState.provinces).map(([id, province]) => (
@@ -23,7 +24,7 @@ export function ProvincePanel() {
               </option>
             ))}
         </select>
-        <ChevronDown className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-400" />
+        <ChevronDown className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4" style={{ color: 'var(--color-text-muted)' }} />
       </div>
 
       {fullState?.provinces && fullState.provinces[selectedProvinceId] && (
@@ -36,67 +37,67 @@ export function ProvincePanel() {
 function ProvinceDetails({ province: p }: { province: ProvinceData }) {
   return (
     <div className="space-y-3">
-      <div className="rounded-xl border border-purple-100 bg-purple-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-purple-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-province-name-border)', borderStyle: 'solid', backgroundColor: 'var(--color-province-name-bg)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-province-name-text)' }}>
           <MapPin className="h-4 w-4" />
           <span>省份名称</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">{p.name}</p>
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>{p.name}</p>
       </div>
 
-      <div className="rounded-xl border border-amber-100 bg-amber-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-amber-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-warning-border)', borderStyle: 'solid', backgroundColor: 'var(--color-warning-soft)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-warning-text)' }}>
           <Coins className="h-4 w-4" />
           <span>产值</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={Number(p.production_value)} delta={p.production_value_delta} />
         </p>
       </div>
 
-      <div className="rounded-xl border border-blue-100 bg-blue-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-blue-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-info-border)', borderStyle: 'solid', backgroundColor: 'var(--color-info-soft)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-info-text)' }}>
           <Users className="h-4 w-4" />
           <span>人口</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={Number(p.population)} delta={p.population_delta} />
         </p>
       </div>
 
-      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-slate-500">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
           <Coins className="h-4 w-4" />
           <span>库存</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={Number(p.stockpile)} delta={p.stockpile_delta} />
         </p>
       </div>
 
-      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-slate-500">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
           <span className="font-mono">💰</span>
           <span>固定支出</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>
           <DeltaValue value={Number(p.fixed_expenditure)} delta={p.fixed_expenditure_delta} />
         </p>
       </div>
 
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-green-100 bg-green-50 p-3">
-          <div className="text-xs text-green-700">产值增长率</div>
-          <p className="mt-1 text-sm font-semibold">
+        <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-province-green-border)', borderStyle: 'solid', backgroundColor: 'var(--color-province-green-bg)' }}>
+          <div className="text-xs" style={{ color: 'var(--color-province-green-text)' }}>产值增长率</div>
+          <p className="mt-1 text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
             <IncidentEffect
               value={Number(p.base_production_growth || 0) * 100}
               incidentEffect={p.production_growth_incident}
             />
           </p>
         </div>
-        <div className="rounded-xl border border-cyan-100 bg-cyan-50 p-3">
-          <div className="text-xs text-cyan-700">人口增长率</div>
-          <p className="mt-1 text-sm font-semibold">
+        <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-province-cyan-border)', borderStyle: 'solid', backgroundColor: 'var(--color-province-cyan-bg)' }}>
+          <div className="text-xs" style={{ color: 'var(--color-province-cyan-text)' }}>人口增长率</div>
+          <p className="mt-1 text-sm font-semibold" style={{ color: 'var(--color-text)' }}>
             <IncidentEffect
               value={Number(p.base_population_growth || 0) * 100}
               incidentEffect={p.population_growth_incident}
@@ -105,12 +106,12 @@ function ProvinceDetails({ province: p }: { province: ProvinceData }) {
         </div>
       </div>
 
-      <div className="rounded-xl border border-orange-100 bg-orange-50 p-3">
-        <div className="flex items-center gap-2 text-xs text-orange-700">
+      <div className="rounded-xl p-3" style={{ borderWidth: 1, borderColor: 'var(--color-province-orange-border)', borderStyle: 'solid', backgroundColor: 'var(--color-province-orange-bg)' }}>
+        <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-province-orange-text)' }}>
           <span className="font-mono">%</span>
           <span>税率</span>
         </div>
-        <p className="mt-2 text-lg font-semibold">
+        <p className="mt-2 text-lg font-semibold" style={{ color: 'var(--color-text)' }}>
           <IncidentEffect
             value={Number(p.actual_tax_rate || 0.1) * 100}
             incidentEffect={p.tax_modifier_incident}

--- a/web/src/components/layout/LeftSidebar.tsx
+++ b/web/src/components/layout/LeftSidebar.tsx
@@ -66,29 +66,31 @@ export function LeftSidebar({
 
   return (
     <>
-      <aside className="flex w-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white lg:w-[320px]">
+      <aside className="flex w-full min-h-0 flex-col overflow-hidden rounded-2xl lg:w-[320px]" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
         {/* Agent sessions */}
         <div className="flex flex-col min-h-0" style={{ height: `${leftPanelSplit}%` }}>
-          <div className="border-b border-slate-200 px-4 py-3 flex items-center justify-between">
-            <h2 className="text-base font-semibold">百官行述</h2>
+          <div className="px-4 py-3 flex items-center justify-between" style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }}>
+            <h2 className="text-base font-semibold" style={{ color: 'var(--color-text)' }}>百官行述</h2>
             <div className="relative" ref={menuRef}>
               <button
                 type="button"
                 onClick={() => setShowAgentMenu((prev) => !prev)}
-                className="rounded-md border border-slate-200 bg-white p-1 hover:bg-slate-100"
+                className="rounded-md p-1 hover:opacity-80"
+                style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
                 title="官员管理"
               >
                 <MoreVertical className="h-3.5 w-3.5" />
               </button>
               {showAgentMenu && (
-                <div className="absolute right-0 top-full z-10 mt-1 w-32 rounded-lg border border-slate-200 bg-white shadow-lg">
+                <div className="absolute right-0 top-full z-10 mt-1 w-32 rounded-lg shadow-lg" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
                   <button
                     type="button"
                     onClick={() => {
                       setShowAgentMenu(false);
                       setShowAddAgentDialog(true);
                     }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-xs text-slate-700 hover:bg-slate-50"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-xs hover:opacity-80"
+                    style={{ color: 'var(--color-text)' }}
                   >
                     <UserPlus className="h-3.5 w-3.5" />
                     新增官员
@@ -96,7 +98,8 @@ export function LeftSidebar({
                   <button
                     type="button"
                     disabled
-                    className="flex w-full items-center gap-2 px-3 py-2 text-xs text-slate-400 hover:bg-slate-50 disabled:opacity-50"
+                    className="flex w-full items-center gap-2 px-3 py-2 text-xs disabled:opacity-50"
+                    style={{ color: 'var(--color-text-muted)' }}
                     title="功能开发中"
                   >
                     调任官员
@@ -108,22 +111,22 @@ export function LeftSidebar({
           <div className="flex-1 overflow-y-auto px-3 py-2">
             <div className="space-y-2">
               {agentSessions.map((group) => (
-                <div key={group.agent_id} className="rounded-lg border border-slate-200 bg-slate-50 p-2">
+                <div key={group.agent_id} className="rounded-lg p-2" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
                   <div className="mb-1 flex items-center justify-between gap-2 px-1">
                     <button
                       type="button"
                       onClick={() => toggleAgent(group.agent_id)}
-                      className="flex min-w-0 flex-1 items-center gap-1 rounded-md px-1 py-1 text-left hover:bg-slate-100"
+                      className="flex min-w-0 flex-1 items-center gap-1 rounded-md px-1 py-1 text-left hover:opacity-80"
                     >
                       {expandedAgents[group.agent_id] ? (
-                        <ChevronDown className="h-3.5 w-3.5 text-slate-500" />
+                        <ChevronDown className="h-3.5 w-3.5" style={{ color: 'var(--color-text-secondary)' }} />
                       ) : (
-                        <ChevronRight className="h-3.5 w-3.5 text-slate-500" />
+                        <ChevronRight className="h-3.5 w-3.5" style={{ color: 'var(--color-text-secondary)' }} />
                       )}
-                      <p className="truncate text-xs font-semibold text-slate-700">
+                      <p className="truncate text-xs font-semibold" style={{ color: 'var(--color-text)' }}>
                         {group.agent_name}
                       </p>
-                      <span className="rounded-md bg-slate-200 px-1 py-0.5 text-[10px] text-slate-600">
+                      <span className="rounded-md px-1 py-0.5 text-[10px]" style={{ backgroundColor: 'var(--color-surface-active)', color: 'var(--color-text-secondary)' }}>
                         {group.sessions.length}
                       </span>
                     </button>
@@ -131,7 +134,8 @@ export function LeftSidebar({
                       type="button"
                       onClick={() => onCreateSession(group.agent_id)}
                       disabled={creatingAgentId === group.agent_id}
-                      className="rounded-md border border-slate-200 bg-white p-0.5 hover:bg-slate-100 disabled:opacity-60"
+                      className="rounded-md p-0.5 disabled:opacity-60 hover:opacity-80"
+                      style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
                       title={`为 ${group.agent_name} 新建会话`}
                     >
                       <Plus className="h-3.5 w-3.5" />
@@ -139,32 +143,38 @@ export function LeftSidebar({
                   </div>
 
                   {expandedAgents[group.agent_id] && (
-                    <div className="ml-2 border-l border-slate-300 pl-2">
+                    <div className="ml-2 pl-2" style={{ borderLeftWidth: 1, borderLeftColor: 'var(--color-border-strong)', borderLeftStyle: 'solid' }}>
                       <div className="space-y-1">
-                        {group.sessions.map((session) => (
-                          <button
-                            key={`${group.agent_id}-${session.session_id}`}
-                            type="button"
-                            onClick={() => onSelectSession(group.agent_id, session.session_id)}
-                            className={`w-full rounded-lg border px-2 py-1.5 text-left text-xs ${
-                              group.agent_id === currentAgentId &&
-                              session.session_id === currentSessionId
-                                ? 'border-blue-300 bg-blue-50'
-                                : 'border-slate-200 bg-white hover:bg-slate-50'
-                            }`}
-                          >
-                            <div className="flex items-center gap-1.5">
-                              <MessageSquare className="h-3 w-3 text-slate-400" />
-                              <p className="truncate font-medium">{session.title}</p>
-                            </div>
-                            <p className="mt-0.5 text-[10px] text-slate-500">
-                              {session.event_count} 条
-                            </p>
-                          </button>
-                        ))}
+                        {group.sessions.map((session) => {
+                          const isActive =
+                            group.agent_id === currentAgentId &&
+                            session.session_id === currentSessionId;
+                          return (
+                            <button
+                              key={`${group.agent_id}-${session.session_id}`}
+                              type="button"
+                              onClick={() => onSelectSession(group.agent_id, session.session_id)}
+                              className="w-full rounded-lg px-2 py-1.5 text-left text-xs"
+                              style={{
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: isActive ? 'var(--color-primary-border)' : 'var(--color-border)',
+                                backgroundColor: isActive ? 'var(--color-primary-soft)' : 'var(--color-surface)',
+                              }}
+                            >
+                              <div className="flex items-center gap-1.5">
+                                <MessageSquare className="h-3 w-3" style={{ color: 'var(--color-text-muted)' }} />
+                                <p className="truncate font-medium" style={{ color: 'var(--color-text)' }}>{session.title}</p>
+                              </div>
+                              <p className="mt-0.5 text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
+                                {session.event_count} 条
+                              </p>
+                            </button>
+                          );
+                        })}
                       </div>
                       {group.sessions.length === 0 && (
-                        <div className="rounded-lg border border-dashed border-slate-300 bg-white px-2 py-1.5 text-[10px] text-slate-500">
+                        <div className="rounded-lg px-2 py-1.5 text-[10px]" style={{ borderWidth: 1, borderColor: 'var(--color-border-strong)', borderStyle: 'dashed', backgroundColor: 'var(--color-surface)', color: 'var(--color-text-secondary)' }}>
                           暂无会话
                         </div>
                       )}
@@ -175,7 +185,7 @@ export function LeftSidebar({
             </div>
 
             {agentSessions.length === 0 && (
-              <div className="rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs text-slate-500">
+              <div className="rounded-lg px-3 py-2 text-xs" style={{ borderWidth: 1, borderColor: 'var(--color-border-strong)', borderStyle: 'dashed', color: 'var(--color-text-secondary)' }}>
                 暂无可用 agent 会话
               </div>
             )}
@@ -195,12 +205,13 @@ export function LeftSidebar({
           className="flex flex-col min-h-0 -mt-2"
           style={{ height: `${100 - leftPanelSplit}%` }}
         >
-          <div className="border-b border-slate-200 px-4 py-3 flex items-center justify-between">
-            <h2 className="text-base font-semibold">群聊</h2>
+          <div className="px-4 py-3 flex items-center justify-between" style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }}>
+            <h2 className="text-base font-semibold" style={{ color: 'var(--color-text)' }}>群聊</h2>
             <button
               type="button"
               onClick={() => setShowCreateGroupDialog(true)}
-              className="rounded-md border border-slate-200 bg-white p-1 hover:bg-slate-100"
+              className="rounded-md p-1 hover:opacity-80"
+              style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
               title="创建群聊"
             >
               <Plus className="h-3.5 w-3.5" />
@@ -209,33 +220,39 @@ export function LeftSidebar({
           <div className="flex-1 overflow-y-auto px-3 py-2">
             {groupChats.length > 0 ? (
               <div className="space-y-2">
-                {groupChats.map((group) => (
-                  <button
-                    key={group.group_id}
-                    type="button"
-                    onClick={() => onSelectGroup(group)}
-                    className={`w-full rounded-lg border px-2 py-2 text-left text-xs ${
-                      currentGroupId === group.group_id
-                        ? 'border-purple-300 bg-purple-50'
-                        : 'border-slate-200 bg-white hover:bg-slate-50'
-                    }`}
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <Users className="h-3 w-3 text-purple-400" />
-                      <p className="truncate font-medium">{group.name}</p>
-                    </div>
-                    <p className="mt-0.5 text-[10px] text-slate-500">
-                      {group.agent_ids.length} 成员 · {group.message_count} 消息
-                    </p>
-                  </button>
-                ))}
+                {groupChats.map((group) => {
+                  const isActive = currentGroupId === group.group_id;
+                  return (
+                    <button
+                      key={group.group_id}
+                      type="button"
+                      onClick={() => onSelectGroup(group)}
+                      className="w-full rounded-lg px-2 py-2 text-left text-xs"
+                      style={{
+                        borderWidth: 1,
+                        borderStyle: 'solid',
+                        borderColor: isActive ? 'var(--color-accent-border)' : 'var(--color-border)',
+                        backgroundColor: isActive ? 'var(--color-accent-soft)' : 'var(--color-surface)',
+                      }}
+                    >
+                      <div className="flex items-center gap-1.5">
+                        <Users className="h-3 w-3" style={{ color: 'var(--color-accent-muted)' }} />
+                        <p className="truncate font-medium" style={{ color: 'var(--color-text)' }}>{group.name}</p>
+                      </div>
+                      <p className="mt-0.5 text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
+                        {group.agent_ids.length} 成员 · {group.message_count} 消息
+                      </p>
+                    </button>
+                  );
+                })}
               </div>
             ) : (
               <div className="flex h-full items-center justify-center">
                 <button
                   type="button"
                   onClick={() => setShowCreateGroupDialog(true)}
-                  className="w-full rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-4 text-xs text-slate-500 hover:bg-slate-100"
+                  className="w-full rounded-lg px-3 py-4 text-xs hover:opacity-80"
+                  style={{ borderWidth: 1, borderColor: 'var(--color-border-strong)', borderStyle: 'dashed', backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text-secondary)' }}
                 >
                   <div className="flex flex-col items-center gap-2">
                     <Users className="h-5 w-5" />

--- a/web/src/components/layout/RightSidebar.tsx
+++ b/web/src/components/layout/RightSidebar.tsx
@@ -65,20 +65,26 @@ export function RightSidebar({
 
   const [tapeContextHeight, setTapeContextHeight] = useState(300);
 
+  const tabClass = (active: boolean) => ({
+    backgroundColor: active ? 'var(--color-primary-soft)' : 'var(--color-surface-hover)',
+    color: active ? 'var(--color-primary-text)' : 'var(--color-text-secondary)',
+  });
+
   return (
     <>
-      <aside className="flex w-full min-h-0 flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white lg:w-[360px]">
+      <aside className="flex w-full min-h-0 flex-col overflow-hidden rounded-2xl lg:w-[360px]" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
         {/* Header with turn info and tabs */}
-        <div className="border-b border-slate-200 px-4 py-4">
+        <div className="px-4 py-4" style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <h3 className="text-lg font-semibold">{formatTurn(overview.turn)}</h3>
+              <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text)' }}>{formatTurn(overview.turn)}</h3>
             </div>
             <button
               type="button"
               onClick={onRefresh}
               disabled={refreshing}
-              className="rounded-lg border border-slate-200 p-1.5 text-slate-600 hover:bg-slate-100 disabled:opacity-60"
+              className="rounded-lg p-1.5 disabled:opacity-60 hover:opacity-80"
+              style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', color: 'var(--color-text-secondary)' }}
               title="刷新"
             >
               <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />
@@ -88,11 +94,8 @@ export function RightSidebar({
             <button
               type="button"
               onClick={() => setCurrentPanelTab('overview')}
-              className={`rounded-md px-2 py-1 font-medium ${
-                currentPanelTab === 'overview'
-                  ? 'bg-blue-50 text-blue-700'
-                  : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
-              }`}
+              className="rounded-md px-2 py-1 font-medium"
+              style={tabClass(currentPanelTab === 'overview')}
             >
               帝国概况
             </button>
@@ -102,15 +105,12 @@ export function RightSidebar({
                 setCurrentPanelTab('incidents');
                 onFetchIncidents();
               }}
-              className={`rounded-md px-2 py-1 font-medium ${
-                currentPanelTab === 'incidents'
-                  ? 'bg-blue-50 text-blue-700'
-                  : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
-              }`}
+              className="rounded-md px-2 py-1 font-medium"
+              style={tabClass(currentPanelTab === 'incidents')}
             >
               天下大事
               {incidents.length > 0 && (
-                <span className="ml-1 rounded-full bg-red-500 px-1.5 py-0.5 text-xs text-white">
+                <span className="ml-1 rounded-full px-1.5 py-0.5 text-xs" style={{ backgroundColor: 'var(--color-danger)', color: 'var(--color-text-inverse)' }}>
                   {incidents.length}
                 </span>
               )}
@@ -121,11 +121,8 @@ export function RightSidebar({
                 setCurrentPanelTab('province');
                 onFetchFullState();
               }}
-              className={`rounded-md px-2 py-1 font-medium ${
-                currentPanelTab === 'province'
-                  ? 'bg-blue-50 text-blue-700'
-                  : 'bg-slate-100 text-slate-500 hover:bg-slate-200'
-              }`}
+              className="rounded-md px-2 py-1 font-medium"
+              style={tabClass(currentPanelTab === 'province')}
             >
               省份概况
             </button>
@@ -139,7 +136,6 @@ export function RightSidebar({
           {currentPanelTab === 'province' && <ProvincePanel />}
         </div>
 
-        {/* Tape context drag handle — reuse VerticalResizeHandle */}
         <VerticalResizeHandle
           onDrag={(deltaY) => {
             const aside = document.querySelectorAll('aside')[1];
@@ -157,15 +153,15 @@ export function RightSidebar({
           style={{ height: tapeContextHeight }}
         >
           <div className="mb-3 flex items-center justify-between">
-            <h4 className="text-base font-semibold">TAPE CONTEXT</h4>
-            <span className="text-xs text-slate-500">{tapeContextEvents.length} 条</span>
+            <h4 className="text-base font-semibold" style={{ color: 'var(--color-text)' }}>TAPE CONTEXT</h4>
+            <span className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>{tapeContextEvents.length} 条</span>
           </div>
 
           {/* Agent selector / info */}
-          <div className="mb-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm">
+          <div className="mb-3 rounded-lg px-3 py-2 text-sm" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
             {currentGroupId ? (
               <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-purple-500" />
+                <Users className="h-4 w-4" style={{ color: 'var(--color-accent-muted)' }} />
                 <select
                   value={selectedGroupAgentId || currentAgentId}
                   onChange={(e) => {
@@ -176,7 +172,8 @@ export function RightSidebar({
                       selectedViewSessionId || currentSessionId,
                     );
                   }}
-                  className="flex-1 rounded border border-slate-200 bg-white px-2 py-1 text-sm outline-none focus:border-purple-300"
+                  className="flex-1 rounded px-2 py-1 text-sm outline-none"
+                  style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)', color: 'var(--color-text)' }}
                 >
                   {(() => {
                     const group = groupChats.find((g) => g.group_id === currentGroupId);
@@ -195,11 +192,11 @@ export function RightSidebar({
               </div>
             ) : (
               <div className="flex items-center gap-2">
-                <CalendarClock className="h-4 w-4 text-slate-500" />
-                <span className="truncate">{viewAgentId}</span>
+                <CalendarClock className="h-4 w-4" style={{ color: 'var(--color-text-secondary)' }} />
+                <span className="truncate" style={{ color: 'var(--color-text)' }}>{viewAgentId}</span>
               </div>
             )}
-            <div className="flex items-center gap-2 text-xs text-slate-500">
+            <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--color-text-secondary)' }}>
               <span>·</span>
               <span className="truncate">
                 {viewTape.session_id
@@ -210,7 +207,7 @@ export function RightSidebar({
           </div>
 
           {/* Sub-session selector */}
-          <div className="mb-3 rounded-lg border border-slate-200 bg-white">
+          <div className="mb-3 rounded-lg" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
             <button
               type="button"
               onClick={() => {
@@ -219,73 +216,83 @@ export function RightSidebar({
                 }
                 setShowSubSessions(!showSubSessions);
               }}
-              className="flex w-full items-center justify-between px-3 py-2 text-sm hover:bg-slate-50"
+              className="flex w-full items-center justify-between px-3 py-2 text-sm hover:opacity-80"
             >
-              <span className="font-medium text-slate-700">切换Session</span>
+              <span className="font-medium" style={{ color: 'var(--color-text)' }}>切换Session</span>
               {selectedViewSessionId &&
                 selectedViewSessionId !== currentSessionId && (
-                  <span className="rounded-md bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+                  <span className="rounded-md px-2 py-0.5 text-xs" style={{ backgroundColor: 'var(--color-primary-soft)', color: 'var(--color-primary-text)' }}>
                     已切换
                   </span>
                 )}
               {showSubSessions ? (
-                <ChevronDown className="h-4 w-4 text-slate-500" />
+                <ChevronDown className="h-4 w-4" style={{ color: 'var(--color-text-secondary)' }} />
               ) : (
-                <ChevronRight className="h-4 w-4 text-slate-500" />
+                <ChevronRight className="h-4 w-4" style={{ color: 'var(--color-text-secondary)' }} />
               )}
             </button>
 
             {showSubSessions && (
-              <div className="border-t border-slate-200 p-3">
+              <div className="p-3" style={{ borderTopWidth: 1, borderTopColor: 'var(--color-border)', borderTopStyle: 'solid' }}>
                 {loadingSubSessions ? (
-                  <div className="py-2 text-center text-sm text-slate-500">加载中...</div>
+                  <div className="py-2 text-center text-sm" style={{ color: 'var(--color-text-secondary)' }}>加载中...</div>
                 ) : (
                   <div className="space-y-1">
-                    <span className="text-xs text-slate-500">选择要查看的Session</span>
+                    <span className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>选择要查看的Session</span>
                     <div className="max-h-40 space-y-1 overflow-y-auto mt-2">
-                      <button
-                        type="button"
-                        onClick={() => onSwitchViewSession(currentSessionId)}
-                        className={`flex w-full items-center gap-2 rounded-md border px-2 py-1.5 text-sm text-left ${
-                          selectedViewSessionId === currentSessionId ||
-                          !selectedViewSessionId
-                            ? 'border-blue-300 bg-blue-50'
-                            : 'border-slate-200 hover:bg-slate-50'
-                        }`}
-                      >
-                        <span className="flex-1 truncate text-slate-700">
-                          主会话 ({currentSessionId.slice(-12)})
-                        </span>
-                        {(selectedViewSessionId === currentSessionId ||
-                          !selectedViewSessionId) && (
-                          <span className="text-xs text-blue-600">● 当前</span>
-                        )}
-                      </button>
+                      {(() => {
+                        const isMainActive = selectedViewSessionId === currentSessionId || !selectedViewSessionId;
+                        return (
+                          <button
+                            type="button"
+                            onClick={() => onSwitchViewSession(currentSessionId)}
+                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left"
+                            style={{
+                              borderWidth: 1,
+                              borderStyle: 'solid',
+                              borderColor: isMainActive ? 'var(--color-primary-border)' : 'var(--color-border)',
+                              backgroundColor: isMainActive ? 'var(--color-primary-soft)' : 'transparent',
+                            }}
+                          >
+                            <span className="flex-1 truncate" style={{ color: 'var(--color-text)' }}>
+                              主会话 ({currentSessionId.slice(-12)})
+                            </span>
+                            {isMainActive && (
+                              <span className="text-xs" style={{ color: 'var(--color-primary)' }}>● 当前</span>
+                            )}
+                          </button>
+                        );
+                      })()}
                       {subSessions.length === 0 ? (
-                        <div className="py-2 text-center text-sm text-slate-500">
+                        <div className="py-2 text-center text-sm" style={{ color: 'var(--color-text-secondary)' }}>
                           暂无子Session
                         </div>
                       ) : (
-                        subSessions.map((sub) => (
-                          <button
-                            key={sub.session_id}
-                            type="button"
-                            onClick={() => onSwitchViewSession(sub.session_id)}
-                            className={`flex w-full items-center gap-2 rounded-md border px-2 py-1.5 text-sm text-left ${
-                              selectedViewSessionId === sub.session_id
-                                ? 'border-blue-300 bg-blue-50'
-                                : 'border-slate-200 hover:bg-slate-50'
-                            }`}
-                          >
-                            <span className="flex-1 truncate text-slate-700">
-                              {sub.session_id.slice(-20)}
-                            </span>
-                            <span className="text-xs text-slate-400">{sub.event_count} 事件</span>
-                            {selectedViewSessionId === sub.session_id && (
-                              <span className="text-xs text-blue-600">● 当前</span>
-                            )}
-                          </button>
-                        ))
+                        subSessions.map((sub) => {
+                          const isActive = selectedViewSessionId === sub.session_id;
+                          return (
+                            <button
+                              key={sub.session_id}
+                              type="button"
+                              onClick={() => onSwitchViewSession(sub.session_id)}
+                              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left"
+                              style={{
+                                borderWidth: 1,
+                                borderStyle: 'solid',
+                                borderColor: isActive ? 'var(--color-primary-border)' : 'var(--color-border)',
+                                backgroundColor: isActive ? 'var(--color-primary-soft)' : 'transparent',
+                              }}
+                            >
+                              <span className="flex-1 truncate" style={{ color: 'var(--color-text)' }}>
+                                {sub.session_id.slice(-20)}
+                              </span>
+                              <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{sub.event_count} 事件</span>
+                              {isActive && (
+                                <span className="text-xs" style={{ color: 'var(--color-primary)' }}>● 当前</span>
+                              )}
+                            </button>
+                          );
+                        })
                       )}
                     </div>
                   </div>
@@ -297,7 +304,7 @@ export function RightSidebar({
           {/* Tape event list */}
           <div className="min-h-0 flex-1 overflow-y-auto space-y-2">
             {tapeContextEvents.length === 0 && (
-              <div className="rounded-xl border border-dashed border-slate-300 px-3 py-4 text-sm text-slate-500">
+              <div className="rounded-xl px-3 py-4 text-sm" style={{ borderWidth: 1, borderColor: 'var(--color-border-strong)', borderStyle: 'dashed', color: 'var(--color-text-secondary)' }}>
                 当前 session 暂无 tape 事件。
               </div>
             )}
@@ -321,7 +328,7 @@ export function RightSidebar({
                       {event.type}
                     </span>
                   </div>
-                  <p className="text-sm text-slate-700">{extractEventText(event)}</p>
+                  <p className="text-sm" style={{ color: 'var(--color-text)' }}>{extractEventText(event)}</p>
                 </div>
               );
             })}

--- a/web/src/components/layout/ThemeToggle.tsx
+++ b/web/src/components/layout/ThemeToggle.tsx
@@ -1,9 +1,10 @@
 import { Moon, Sun } from 'lucide-react';
 
-import { useTheme } from '../../theme/useTheme';
+import { useThemeStore } from '../../theme/useTheme';
 
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
 
   return (
     <button

--- a/web/src/components/layout/ThemeToggle.tsx
+++ b/web/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+import { Moon, Sun } from 'lucide-react';
+
+import { useTheme } from '../../theme/useTheme';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="fixed bottom-5 right-5 z-40 rounded-full p-2.5 shadow-lg transition-colors"
+      style={{
+        backgroundColor: 'var(--color-surface)',
+        color: 'var(--color-text-secondary)',
+        borderWidth: 1,
+        borderColor: 'var(--color-border)',
+        borderStyle: 'solid',
+      }}
+      title={theme === 'light' ? '切换到深色模式' : '切换到浅色模式'}
+    >
+      {theme === 'light' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/web/src/components/layout/VerticalResizeHandle.tsx
+++ b/web/src/components/layout/VerticalResizeHandle.tsx
@@ -28,9 +28,8 @@ export function VerticalResizeHandle({ onDrag }: VerticalResizeHandleProps) {
 
   return (
     <div
-      className={`flex items-center justify-center gap-1.5 py-1 cursor-row-resize select-none group relative z-10 ${
-        isDragging ? 'bg-slate-100' : ''
-      }`}
+      className="flex items-center justify-center gap-1.5 py-1 cursor-row-resize select-none group relative z-10"
+      style={isDragging ? { backgroundColor: 'var(--color-surface-hover)' } : undefined}
       onMouseDown={(e) => {
         e.preventDefault();
         setIsDragging(true);
@@ -39,9 +38,10 @@ export function VerticalResizeHandle({ onDrag }: VerticalResizeHandleProps) {
       {[0, 1, 2, 3, 4].map((i) => (
         <span
           key={i}
-          className={`w-1 h-1 rounded-full transition-all ${
-            isDragging ? 'bg-blue-500' : 'bg-slate-300 group-hover:bg-blue-400'
-          }`}
+          className="w-1 h-1 rounded-full transition-all"
+          style={{
+            backgroundColor: isDragging ? 'var(--color-dot-active)' : 'var(--color-dot)',
+          }}
         />
       ))}
     </div>

--- a/web/src/components/rich/AgentMessageBlock.tsx
+++ b/web/src/components/rich/AgentMessageBlock.tsx
@@ -1,7 +1,7 @@
 import { MessageCircle } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
-import { getAgentToken } from '../../theme/agent-tokens';
+import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
 import { extractEventText } from '../../utils/tape';
 import { renderMarkdown } from '../../utils/render';
 import { formatDate } from '../../utils/format';
@@ -14,6 +14,7 @@ interface AgentMessageBlockProps {
 export function AgentMessageBlock({ event, compact = false }: AgentMessageBlockProps) {
   const srcId = event.src.replace('agent:', '');
   const srcToken = getAgentToken(srcId);
+  const srcColors = getActiveColors(srcToken);
   const dstNames = event.dst
     .map((d) => {
       const id = d.replace('agent:', '');
@@ -25,22 +26,22 @@ export function AgentMessageBlock({ event, compact = false }: AgentMessageBlockP
 
   return (
     <div
-      className="rounded-xl border border-dashed px-3 py-2"
-      style={{ borderColor: `${srcToken.color}60`, backgroundColor: `${srcToken.bgColor}50` }}
+      className="rounded-xl border-dashed px-3 py-2"
+      style={{ borderWidth: 1, borderStyle: 'dashed', borderColor: `${srcColors.color}60`, backgroundColor: `${srcColors.bgColor}50` }}
     >
       <div className="mb-1 flex items-center gap-2">
-        <MessageCircle className="h-3.5 w-3.5" style={{ color: srcToken.color }} />
-        <span className="text-xs font-semibold" style={{ color: srcToken.color }}>
+        <MessageCircle className="h-3.5 w-3.5" style={{ color: srcColors.color }} />
+        <span className="text-xs font-semibold" style={{ color: srcColors.color }}>
           {srcToken.icon} {srcToken.displayName}
         </span>
-        <span className="text-xs text-slate-400">{'>'}</span>
-        <span className="text-xs text-slate-600">{dstNames}</span>
-        <span className="ml-auto text-[10px] text-slate-400">{formatDate(event.timestamp)}</span>
+        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{'>'}</span>
+        <span className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>{dstNames}</span>
+        <span className="ml-auto text-[10px]" style={{ color: 'var(--color-text-muted)' }}>{formatDate(event.timestamp)}</span>
       </div>
 
       {text && (
         compact ? (
-          <p className="text-xs text-slate-600 line-clamp-2">{text}</p>
+          <p className="text-xs line-clamp-2" style={{ color: 'var(--color-text-secondary)' }}>{text}</p>
         ) : (
           renderMarkdown(text, false)
         )

--- a/web/src/components/rich/AgentMessageBlock.tsx
+++ b/web/src/components/rich/AgentMessageBlock.tsx
@@ -2,6 +2,7 @@ import { MessageCircle } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
 import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
+import { useThemeStore } from '../../theme/useTheme';
 import { extractEventText } from '../../utils/tape';
 import { renderMarkdown } from '../../utils/render';
 import { formatDate } from '../../utils/format';
@@ -12,9 +13,10 @@ interface AgentMessageBlockProps {
 }
 
 export function AgentMessageBlock({ event, compact = false }: AgentMessageBlockProps) {
+  const theme = useThemeStore((s) => s.theme);
   const srcId = event.src.replace('agent:', '');
   const srcToken = getAgentToken(srcId);
-  const srcColors = getActiveColors(srcToken);
+  const srcColors = getActiveColors(srcToken, theme);
   const dstNames = event.dst
     .map((d) => {
       const id = d.replace('agent:', '');

--- a/web/src/components/rich/IncidentBlock.tsx
+++ b/web/src/components/rich/IncidentBlock.tsx
@@ -12,7 +12,6 @@ const PATH_LABELS: Record<string, string> = {
 function resolvePathLabel(path: string): string {
   if (PATH_LABELS[path]) return PATH_LABELS[path];
 
-  // Try to resolve province-specific paths
   const match = path.match(/^provinces\.(\w+)\.(\w+)$/);
   if (match) {
     const [, province, field] = match;
@@ -67,19 +66,19 @@ export function IncidentBlock({ event, compact = false }: IncidentBlockProps) {
   const effects = Array.isArray(payload.effects) ? payload.effects as { target_path: string; add?: string | null; factor?: string | null }[] : [];
 
   return (
-    <div className="rounded-xl border border-amber-200 bg-amber-50/70 px-3 py-2">
+    <div className="rounded-xl px-3 py-2" style={{ borderWidth: 1, borderColor: 'var(--color-warning-border)', borderStyle: 'solid', backgroundColor: 'var(--color-warning-soft)' }}>
       <div className="mb-1 flex items-center gap-2">
-        <Zap className="h-3.5 w-3.5 text-amber-600" />
-        <span className="text-xs font-semibold text-amber-800">{title}</span>
+        <Zap className="h-3.5 w-3.5" style={{ color: 'var(--color-warning)' }} />
+        <span className="text-xs font-semibold" style={{ color: 'var(--color-warning-strong)' }}>{title}</span>
         {remainingTicks !== null && (
-          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700">
+          <span className="rounded px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: 'var(--color-warning-badge-bg)', color: 'var(--color-warning-text)' }}>
             {remainingTicks} tick
           </span>
         )}
       </div>
 
       {source && (
-        <p className="mb-1 text-[10px] text-amber-600">来源: {source}</p>
+        <p className="mb-1 text-[10px]" style={{ color: 'var(--color-warning)' }}>来源: {source}</p>
       )}
 
       {effects.length > 0 && (
@@ -87,9 +86,9 @@ export function IncidentBlock({ event, compact = false }: IncidentBlockProps) {
           {effects.map((effect, i) => {
             const formatted = formatEffect(effect);
             return (
-              <div key={i} className="flex items-center justify-between rounded bg-white/60 px-2 py-1 text-xs">
-                <span className="text-slate-700">{formatted.label}</span>
-                <span className={formatted.isNegative ? 'font-medium text-red-600' : 'font-medium text-emerald-600'}>
+              <div key={i} className="flex items-center justify-between rounded px-2 py-1 text-xs" style={{ backgroundColor: 'var(--color-surface)' }}>
+                <span style={{ color: 'var(--color-text)' }}>{formatted.label}</span>
+                <span className="font-medium" style={{ color: formatted.isNegative ? 'var(--color-delta-negative)' : 'var(--color-delta-positive)' }}>
                   {formatted.value}
                 </span>
               </div>
@@ -99,7 +98,7 @@ export function IncidentBlock({ event, compact = false }: IncidentBlockProps) {
       )}
 
       {description && !compact && (
-        <p className="mt-1 text-xs text-amber-700">{description}</p>
+        <p className="mt-1 text-xs" style={{ color: 'var(--color-warning-text)' }}>{description}</p>
       )}
     </div>
   );

--- a/web/src/components/rich/SystemNoticeBar.tsx
+++ b/web/src/components/rich/SystemNoticeBar.tsx
@@ -28,17 +28,17 @@ export function SystemNoticeBar({ event }: SystemNoticeBarProps) {
     }
 
     return (
-      <div className="flex items-center justify-center gap-3 rounded-lg bg-amber-50 px-4 py-2 text-xs text-amber-700">
-        <span className="text-amber-500">---</span>
+      <div className="flex items-center justify-center gap-3 rounded-lg px-4 py-2 text-xs" style={{ backgroundColor: 'var(--color-warning-soft)', color: 'var(--color-warning-text)' }}>
+        <span style={{ color: 'var(--color-warning-icon)' }}>---</span>
         <span>{parts.length > 0 ? parts.join(' | ') : '回合结算'}</span>
-        <span className="text-amber-500">---</span>
+        <span style={{ color: 'var(--color-warning-icon)' }}>---</span>
       </div>
     );
   }
 
   if (type === 'shutdown') {
     return (
-      <div className="flex items-center justify-center gap-2 rounded-lg bg-red-50 px-4 py-2 text-xs text-red-600">
+      <div className="flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-xs" style={{ backgroundColor: 'var(--color-danger-soft)', color: 'var(--color-danger)' }}>
         <span>---</span>
         <span>Agent 已关闭</span>
         <span>---</span>
@@ -48,7 +48,7 @@ export function SystemNoticeBar({ event }: SystemNoticeBarProps) {
 
   if (type === 'reload_config') {
     return (
-      <div className="flex items-center justify-center gap-2 rounded-lg bg-blue-50 px-4 py-2 text-xs text-blue-600">
+      <div className="flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-xs" style={{ backgroundColor: 'var(--color-info-soft)', color: 'var(--color-info-text)' }}>
         <span>---</span>
         <span>配置已重新加载</span>
         <span>---</span>
@@ -56,13 +56,12 @@ export function SystemNoticeBar({ event }: SystemNoticeBarProps) {
     );
   }
 
-  // Generic system event
   const text = typeof payload.content === 'string' ? payload.content
     : typeof payload.message === 'string' ? payload.message
     : event.type;
 
   return (
-    <div className="flex items-center justify-center gap-2 rounded-lg bg-slate-50 px-4 py-2 text-xs text-slate-500">
+    <div className="flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-xs" style={{ backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text-secondary)' }}>
       <span>---</span>
       <span>{text}</span>
       <span>---</span>

--- a/web/src/components/rich/TaskSessionBlock.tsx
+++ b/web/src/components/rich/TaskSessionBlock.tsx
@@ -7,48 +7,78 @@ interface TaskSessionBlockProps {
   compact?: boolean;
 }
 
-const STATUS_CONFIG = {
-  task_created: {
-    icon: ListTodo,
-    label: '任务创建',
-    bgClass: 'bg-blue-50/70',
-    borderClass: 'border-blue-200',
-    iconClass: 'text-blue-600',
-    labelClass: 'text-blue-800',
-    badgeClass: 'bg-blue-100 text-blue-700',
-  },
-  task_finished: {
-    icon: ClipboardCheck,
-    label: '任务完成',
-    bgClass: 'bg-emerald-50/70',
-    borderClass: 'border-emerald-200',
-    iconClass: 'text-emerald-600',
-    labelClass: 'text-emerald-800',
-    badgeClass: 'bg-emerald-100 text-emerald-700',
-  },
-  task_failed: {
-    icon: ClipboardX,
-    label: '任务失败',
-    bgClass: 'bg-red-50/70',
-    borderClass: 'border-red-200',
-    iconClass: 'text-red-600',
-    labelClass: 'text-red-800',
-    badgeClass: 'bg-red-100 text-red-700',
-  },
-  task_timeout: {
-    icon: Clock,
-    label: '任务超时',
-    bgClass: 'bg-orange-50/70',
-    borderClass: 'border-orange-200',
-    iconClass: 'text-orange-600',
-    labelClass: 'text-orange-800',
-    badgeClass: 'bg-orange-100 text-orange-700',
-  },
-} as const;
+type TaskStatus = 'task_created' | 'task_finished' | 'task_failed' | 'task_timeout';
+
+interface StatusConfig {
+  icon: typeof ListTodo;
+  label: string;
+  bgColor: string;
+  borderColor: string;
+  iconColor: string;
+  labelColor: string;
+  badgeBg: string;
+  badgeColor: string;
+}
+
+function getStatusConfig(status: TaskStatus, isDark: boolean): StatusConfig {
+  const configs: Record<TaskStatus, { light: StatusConfig; dark: StatusConfig }> = {
+    task_created: {
+      light: {
+        icon: ListTodo, label: '任务创建',
+        bgColor: '#eff6ff', borderColor: '#bfdbfe', iconColor: '#2563eb', labelColor: '#1e40af',
+        badgeBg: '#dbeafe', badgeColor: '#1d4ed8',
+      },
+      dark: {
+        icon: ListTodo, label: '任务创建',
+        bgColor: '#1e3a5f', borderColor: '#1d4ed8', iconColor: '#60a5fa', labelColor: '#93c5fd',
+        badgeBg: '#1e3a5f', badgeColor: '#93c5fd',
+      },
+    },
+    task_finished: {
+      light: {
+        icon: ClipboardCheck, label: '任务完成',
+        bgColor: '#ecfdf5', borderColor: '#a7f3d0', iconColor: '#059669', labelColor: '#065f46',
+        badgeBg: '#d1fae5', badgeColor: '#047857',
+      },
+      dark: {
+        icon: ClipboardCheck, label: '任务完成',
+        bgColor: '#064e3b', borderColor: '#065f46', iconColor: '#34d399', labelColor: '#6ee7b7',
+        badgeBg: '#064e3b', badgeColor: '#6ee7b7',
+      },
+    },
+    task_failed: {
+      light: {
+        icon: ClipboardX, label: '任务失败',
+        bgColor: '#fef2f2', borderColor: '#fecaca', iconColor: '#dc2626', labelColor: '#991b1b',
+        badgeBg: '#fee2e2', badgeColor: '#b91c1c',
+      },
+      dark: {
+        icon: ClipboardX, label: '任务失败',
+        bgColor: '#450a0a', borderColor: '#7f1d1d', iconColor: '#f87171', labelColor: '#fca5a5',
+        badgeBg: '#450a0a', badgeColor: '#fca5a5',
+      },
+    },
+    task_timeout: {
+      light: {
+        icon: Clock, label: '任务超时',
+        bgColor: '#fff7ed', borderColor: '#fed7aa', iconColor: '#ea580c', labelColor: '#9a3412',
+        badgeBg: '#ffedd5', badgeColor: '#c2410c',
+      },
+      dark: {
+        icon: Clock, label: '任务超时',
+        bgColor: '#431407', borderColor: '#7c2d12', iconColor: '#fb923c', labelColor: '#fdba74',
+        badgeBg: '#431407', badgeColor: '#fdba74',
+      },
+    },
+  };
+  return isDark ? configs[status].dark : configs[status].light;
+}
 
 export function TaskSessionBlock({ event, compact = false }: TaskSessionBlockProps) {
-  const type = event.type.toLowerCase() as keyof typeof STATUS_CONFIG;
-  const config = STATUS_CONFIG[type] || STATUS_CONFIG.task_created;
+  const type = event.type.toLowerCase() as TaskStatus;
+  const isDark = typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+  const validTypes: TaskStatus[] = ['task_created', 'task_finished', 'task_failed', 'task_timeout'];
+  const config = getStatusConfig(validTypes.includes(type) ? type : 'task_created', isDark);
   const Icon = config.icon;
   const payload = event.payload ?? {};
 
@@ -59,37 +89,37 @@ export function TaskSessionBlock({ event, compact = false }: TaskSessionBlockPro
   const depth = typeof payload.depth === 'number' ? payload.depth : null;
 
   return (
-    <div className={`rounded-xl border px-3 py-2 ${config.borderClass} ${config.bgClass}`}>
+    <div className="rounded-xl px-3 py-2" style={{ borderWidth: 1, borderStyle: 'solid', borderColor: config.borderColor, backgroundColor: config.bgColor }}>
       <div className="mb-1 flex items-center gap-2">
-        <Icon className={`h-3.5 w-3.5 ${config.iconClass}`} />
-        <span className={`text-xs font-semibold ${config.labelClass}`}>{config.label}</span>
+        <Icon className="h-3.5 w-3.5" style={{ color: config.iconColor }} />
+        <span className="text-xs font-semibold" style={{ color: config.labelColor }}>{config.label}</span>
         {depth !== null && (
-          <span className={`rounded px-1.5 py-0.5 text-[10px] ${config.badgeClass}`}>
+          <span className="rounded px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: config.badgeBg, color: config.badgeColor }}>
             层级 {depth}/5
           </span>
         )}
       </div>
 
       {goal && (
-        <p className="text-xs text-slate-700">
+        <p className="text-xs" style={{ color: 'var(--color-text)' }}>
           <span className="font-medium">目标: </span>{goal}
         </p>
       )}
 
       {result && (
-        <p className={`text-xs text-slate-600 ${compact ? 'line-clamp-2' : ''}`}>
+        <p className={`text-xs ${compact ? 'line-clamp-2' : ''}`} style={{ color: 'var(--color-text-secondary)' }}>
           <span className="font-medium">结果: </span>{result}
         </p>
       )}
 
       {reason && (
-        <p className="text-xs text-red-600">
+        <p className="text-xs" style={{ color: 'var(--color-danger)' }}>
           <span className="font-medium">原因: </span>{reason}
         </p>
       )}
 
       {taskSessionId && !compact && (
-        <p className="mt-1 text-[10px] text-slate-400 truncate">
+        <p className="mt-1 text-[10px] truncate" style={{ color: 'var(--color-text-muted)' }}>
           {taskSessionId}
         </p>
       )}

--- a/web/src/components/rich/ToolCallBlock.tsx
+++ b/web/src/components/rich/ToolCallBlock.tsx
@@ -1,7 +1,7 @@
 import { Wrench } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
-import { getAgentToken } from '../../theme/agent-tokens';
+import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
 import { CollapsibleSection } from './shared/CollapsibleSection';
 import { JsonTable } from './shared/JsonTable';
 
@@ -17,34 +17,35 @@ export function ToolCallBlock({ event, compact = false }: ToolCallBlockProps) {
 
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(agentId);
+  const colors = getActiveColors(token);
 
   if (toolCalls.length === 0) return null;
 
   return (
     <div
       className="rounded-xl border px-3 py-2"
-      style={{ borderColor: `${token.color}40`, backgroundColor: `${token.bgColor}80` }}
+      style={{ borderColor: `${colors.color}40`, backgroundColor: `${colors.bgColor}80` }}
     >
       <div className="mb-1 flex items-center gap-2">
-        <Wrench className="h-3.5 w-3.5" style={{ color: token.color }} />
-        <span className="text-xs font-semibold" style={{ color: token.color }}>
+        <Wrench className="h-3.5 w-3.5" style={{ color: colors.color }} />
+        <span className="text-xs font-semibold" style={{ color: colors.color }}>
           工具调用
         </span>
-        <span className="text-xs text-slate-400">
+        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
           {toolCalls.length} 个工具
         </span>
       </div>
 
       {reasoning && (
         <CollapsibleSection title="推理过程" className="mb-2">
-          <p className="whitespace-pre-wrap text-xs text-slate-600">{reasoning}</p>
+          <p className="whitespace-pre-wrap text-xs" style={{ color: 'var(--color-text-secondary)' }}>{reasoning}</p>
         </CollapsibleSection>
       )}
 
       <div className={compact ? 'space-y-1' : 'space-y-2'}>
         {toolCalls.map((tc, i) => (
-          <div key={i} className="rounded-lg border border-slate-200 bg-white px-2.5 py-1.5">
-            <p className="text-xs font-medium text-slate-700">{tc.name}</p>
+          <div key={i} className="rounded-lg px-2.5 py-1.5" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
+            <p className="text-xs font-medium" style={{ color: 'var(--color-text)' }}>{tc.name}</p>
             {tc.arguments && Object.keys(tc.arguments).length > 0 && !compact && (
               <div className="mt-1">
                 <JsonTable data={tc.arguments} />

--- a/web/src/components/rich/ToolCallBlock.tsx
+++ b/web/src/components/rich/ToolCallBlock.tsx
@@ -2,6 +2,7 @@ import { Wrench } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
 import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
+import { useThemeStore } from '../../theme/useTheme';
 import { CollapsibleSection } from './shared/CollapsibleSection';
 import { JsonTable } from './shared/JsonTable';
 
@@ -11,13 +12,14 @@ interface ToolCallBlockProps {
 }
 
 export function ToolCallBlock({ event, compact = false }: ToolCallBlockProps) {
+  const theme = useThemeStore((s) => s.theme);
   const payload = event.payload ?? {};
   const reasoning = typeof payload.reasoning === 'string' ? payload.reasoning : '';
   const toolCalls = Array.isArray(payload.tool_calls) ? payload.tool_calls as { name: string; arguments: Record<string, unknown> }[] : [];
 
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(agentId);
-  const colors = getActiveColors(token);
+  const colors = getActiveColors(token, theme);
 
   if (toolCalls.length === 0) return null;
 

--- a/web/src/components/rich/ToolResultBlock.tsx
+++ b/web/src/components/rich/ToolResultBlock.tsx
@@ -2,6 +2,7 @@ import { CheckCircle2 } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
 import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
+import { useThemeStore } from '../../theme/useTheme';
 import { JsonTable } from './shared/JsonTable';
 import { CollapsibleSection } from './shared/CollapsibleSection';
 
@@ -58,6 +59,7 @@ function renderResult(tool: string, result: string, compact: boolean) {
 }
 
 export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps) {
+  const theme = useThemeStore((s) => s.theme);
   const payload = event.payload ?? {};
   const tool = typeof payload.tool_name === 'string' ? payload.tool_name
     : typeof payload.tool === 'string' ? payload.tool : '';
@@ -68,7 +70,7 @@ export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps
 
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(agentId);
-  const colors = getActiveColors(token);
+  const colors = getActiveColors(token, theme);
 
   return (
     <div

--- a/web/src/components/rich/ToolResultBlock.tsx
+++ b/web/src/components/rich/ToolResultBlock.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2 } from 'lucide-react';
 
 import type { TapeEvent } from '../../api/types';
-import { getAgentToken } from '../../theme/agent-tokens';
+import { getAgentToken, getActiveColors } from '../../theme/agent-tokens';
 import { JsonTable } from './shared/JsonTable';
 import { CollapsibleSection } from './shared/CollapsibleSection';
 
@@ -22,7 +22,6 @@ function tryParseJson(value: string): Record<string, unknown> | null {
 function renderResult(tool: string, result: string, compact: boolean) {
   const parsed = tryParseJson(result);
 
-  // Structured rendering for known tools
   if (tool === 'query_state' && parsed) {
     return <JsonTable data={parsed} />;
   }
@@ -33,14 +32,14 @@ function renderResult(tool: string, result: string, compact: boolean) {
 
   if (tool === 'search_memory' && parsed) {
     const results = Array.isArray(parsed.results) ? parsed.results : [];
-    if (results.length === 0) return <p className="text-xs text-slate-500">无相关记忆</p>;
+    if (results.length === 0) return <p className="text-xs" style={{ color: 'var(--color-text-secondary)' }}>无相关记忆</p>;
     return (
       <div className="space-y-1">
         {results.map((r: { title?: string; content?: string }, i: number) => (
-          <div key={i} className="rounded border border-slate-100 bg-slate-50 px-2 py-1">
-            {r.title && <p className="text-xs font-medium text-slate-700">{r.title}</p>}
+          <div key={i} className="rounded px-2 py-1" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface-alt)' }}>
+            {r.title && <p className="text-xs font-medium" style={{ color: 'var(--color-text)' }}>{r.title}</p>}
             {r.content && !compact && (
-              <p className="text-xs text-slate-500 line-clamp-2">{r.content}</p>
+              <p className="text-xs line-clamp-2" style={{ color: 'var(--color-text-secondary)' }}>{r.content}</p>
             )}
           </div>
         ))}
@@ -48,21 +47,18 @@ function renderResult(tool: string, result: string, compact: boolean) {
     );
   }
 
-  // JSON result — show as table
   if (parsed) {
     return <JsonTable data={parsed} />;
   }
 
-  // Plain text result
   if (compact && result.length > 100) {
-    return <p className="text-xs text-slate-600 line-clamp-2">{result}</p>;
+    return <p className="text-xs line-clamp-2" style={{ color: 'var(--color-text-secondary)' }}>{result}</p>;
   }
-  return <p className="whitespace-pre-wrap text-xs text-slate-600">{result}</p>;
+  return <p className="whitespace-pre-wrap text-xs" style={{ color: 'var(--color-text-secondary)' }}>{result}</p>;
 }
 
 export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps) {
   const payload = event.payload ?? {};
-  // Backend uses tool_name/output (react.py:185-186), old format uses tool/result
   const tool = typeof payload.tool_name === 'string' ? payload.tool_name
     : typeof payload.tool === 'string' ? payload.tool : '';
   const args = payload.arguments as Record<string, unknown> | undefined;
@@ -72,19 +68,20 @@ export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps
 
   const agentId = event.src.replace('agent:', '');
   const token = getAgentToken(agentId);
+  const colors = getActiveColors(token);
 
   return (
     <div
       className="rounded-xl border px-3 py-2"
-      style={{ borderColor: `${token.color}40`, backgroundColor: `${token.bgColor}80` }}
+      style={{ borderColor: `${colors.color}40`, backgroundColor: `${colors.bgColor}80` }}
     >
       <div className="mb-1 flex items-center gap-2">
-        <CheckCircle2 className="h-3.5 w-3.5" style={{ color: token.color }} />
-        <span className="text-xs font-semibold" style={{ color: token.color }}>
+        <CheckCircle2 className="h-3.5 w-3.5" style={{ color: colors.color }} />
+        <span className="text-xs font-semibold" style={{ color: colors.color }}>
           {tool || '工具结果'}
         </span>
         {endsLoop && (
-          <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] text-emerald-700">
+          <span className="rounded px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: 'var(--color-success-badge-bg)', color: 'var(--color-success-text)' }}>
             结束循环
           </span>
         )}
@@ -97,7 +94,7 @@ export function ToolResultBlock({ event, compact = false }: ToolResultBlockProps
       )}
 
       {result && (
-        <div className="mt-1 rounded-lg border border-slate-100 bg-white p-2">
+        <div className="mt-1 rounded-lg p-2" style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}>
           {renderResult(tool, result, compact)}
         </div>
       )}

--- a/web/src/components/rich/shared/CollapsibleSection.tsx
+++ b/web/src/components/rich/shared/CollapsibleSection.tsx
@@ -21,7 +21,8 @@ export function CollapsibleSection({
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex w-full items-center gap-1 text-xs text-slate-500 hover:text-slate-700"
+        className="flex w-full items-center gap-1 text-xs hover:opacity-80"
+        style={{ color: 'var(--color-text-secondary)' }}
       >
         {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
         <span>{title}</span>

--- a/web/src/components/rich/shared/JsonTable.tsx
+++ b/web/src/components/rich/shared/JsonTable.tsx
@@ -23,9 +23,9 @@ export function JsonTable({ data, className = '' }: JsonTableProps) {
     <table className={`w-full text-xs ${className}`}>
       <tbody>
         {entries.map(([key, value]) => (
-          <tr key={key} className="border-b border-slate-100 last:border-0">
-            <td className="py-1 pr-3 font-medium text-slate-500">{key}</td>
-            <td className="py-1 text-slate-700">{formatValue(value)}</td>
+          <tr key={key} style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }} className="last:border-0">
+            <td className="py-1 pr-3 font-medium" style={{ color: 'var(--color-text-secondary)' }}>{key}</td>
+            <td className="py-1" style={{ color: 'var(--color-text)' }}>{formatValue(value)}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,32 +1,47 @@
+@import './theme/design-tokens.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   body {
-    @apply bg-gray-100 text-gray-800 font-sans;
+    @apply font-sans;
+    background-color: var(--color-app-bg);
+    color: var(--color-text);
   }
 }
 
 @layer components {
-  /* 自定义组件样式 */
   .btn {
     @apply px-4 py-2 rounded font-medium transition-colors;
   }
 
   .btn-primary {
-    @apply bg-blue-600 text-white hover:bg-blue-700;
+    background-color: var(--color-primary);
+    color: var(--color-text-inverse);
+  }
+  .btn-primary:hover {
+    background-color: var(--color-primary-hover);
   }
 
   .btn-secondary {
-    @apply bg-gray-200 text-gray-800 hover:bg-gray-300;
+    background-color: var(--color-surface-active);
+    color: var(--color-text);
+  }
+  .btn-secondary:hover {
+    background-color: var(--color-border-strong);
   }
 
   .card {
-    @apply bg-white rounded-lg shadow-md p-6;
+    background-color: var(--color-surface);
+    @apply rounded-lg shadow-md p-6;
   }
 
   .input {
-    @apply border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500;
+    border-color: var(--color-border);
+    background-color: var(--color-surface);
+    color: var(--color-text);
+    @apply border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500;
   }
 }

--- a/web/src/theme/agent-tokens.ts
+++ b/web/src/theme/agent-tokens.ts
@@ -155,18 +155,18 @@ export function getAgentToken(agentId: string): AgentToken {
 }
 
 /**
- * Returns the active colors for the current theme.
- * Checks for `.dark` class on `<html>`.
+ * Returns the active colors for the given theme.
+ * Pass the theme value from `useThemeStore` to ensure reactivity on toggle.
  */
-export function getActiveColors(token: AgentToken): {
+export function getActiveColors(
+  token: AgentToken,
+  theme: 'light' | 'dark' = 'light',
+): {
   color: string;
   bgColor: string;
   borderColor: string;
 } {
-  const isDark =
-    typeof document !== 'undefined' &&
-    document.documentElement.classList.contains('dark');
-  if (isDark && token.dark) {
+  if (theme === 'dark' && token.dark) {
     return token.dark;
   }
   return { color: token.color, bgColor: token.bgColor, borderColor: token.borderColor };

--- a/web/src/theme/agent-tokens.ts
+++ b/web/src/theme/agent-tokens.ts
@@ -1,6 +1,7 @@
 /**
  * Agent visual identity tokens for the imperial court simulator.
  * Maps agent IDs to colors, icons, and display names.
+ * Provides both light and dark mode color variants.
  */
 
 export interface AgentToken {
@@ -10,15 +11,63 @@ export interface AgentToken {
   bgColor: string;
   borderColor: string;
   icon: string;
+  /** Dark-mode overrides (defaults to light values if absent). */
+  dark?: {
+    color: string;
+    bgColor: string;
+    borderColor: string;
+  };
 }
 
-const FALLBACK_SCHEMES: Array<{ color: string; bgColor: string; borderColor: string; icon: string }> = [
-  { color: '#6A5ACD', bgColor: '#EDE9FE', borderColor: '#6A5ACD', icon: '🏯' },
-  { color: '#2E8B57', bgColor: '#E6F4EA', borderColor: '#2E8B57', icon: '🎋' },
-  { color: '#CD853F', bgColor: '#FFF4E6', borderColor: '#CD853F', icon: '📜' },
-  { color: '#708090', bgColor: '#F0F2F5', borderColor: '#708090', icon: '⚔️' },
-  { color: '#8B4513', bgColor: '#FAF0E6', borderColor: '#8B4513', icon: '🏛️' },
-  { color: '#4682B4', bgColor: '#E8F0FE', borderColor: '#4682B4', icon: '🌊' },
+const FALLBACK_SCHEMES: Array<{
+  color: string;
+  bgColor: string;
+  borderColor: string;
+  icon: string;
+  dark: { color: string; bgColor: string; borderColor: string };
+}> = [
+  {
+    color: '#6A5ACD',
+    bgColor: '#EDE9FE',
+    borderColor: '#6A5ACD',
+    icon: '🏯',
+    dark: { color: '#A78BFA', bgColor: '#2E1065', borderColor: '#7C3AED' },
+  },
+  {
+    color: '#2E8B57',
+    bgColor: '#E6F4EA',
+    borderColor: '#2E8B57',
+    icon: '🎋',
+    dark: { color: '#6EE7B7', bgColor: '#064E3B', borderColor: '#059669' },
+  },
+  {
+    color: '#CD853F',
+    bgColor: '#FFF4E6',
+    borderColor: '#CD853F',
+    icon: '📜',
+    dark: { color: '#FBBF24', bgColor: '#451A03', borderColor: '#B45309' },
+  },
+  {
+    color: '#708090',
+    bgColor: '#F0F2F5',
+    borderColor: '#708090',
+    icon: '⚔️',
+    dark: { color: '#94A3B8', bgColor: '#1E293B', borderColor: '#64748B' },
+  },
+  {
+    color: '#8B4513',
+    bgColor: '#FAF0E6',
+    borderColor: '#8B4513',
+    icon: '🏛️',
+    dark: { color: '#D97706', bgColor: '#431407', borderColor: '#92400E' },
+  },
+  {
+    color: '#4682B4',
+    bgColor: '#E8F0FE',
+    borderColor: '#4682B4',
+    icon: '🌊',
+    dark: { color: '#60A5FA', bgColor: '#1E3A5F', borderColor: '#2563EB' },
+  },
 ];
 
 export const KNOWN_AGENTS: Record<string, AgentToken> = {
@@ -29,6 +78,7 @@ export const KNOWN_AGENTS: Record<string, AgentToken> = {
     bgColor: '#E8F5EC',
     borderColor: '#2D8B56',
     icon: '🌿',
+    dark: { color: '#6EE7B7', bgColor: '#064E3B', borderColor: '#059669' },
   },
   governor_zhili: {
     id: 'governor_zhili',
@@ -37,6 +87,7 @@ export const KNOWN_AGENTS: Record<string, AgentToken> = {
     bgColor: '#FFF8E1',
     borderColor: '#B8860B',
     icon: '🏰',
+    dark: { color: '#FCD34D', bgColor: '#451A03', borderColor: '#B45309' },
   },
   minister_of_revenue: {
     id: 'minister_of_revenue',
@@ -45,6 +96,7 @@ export const KNOWN_AGENTS: Record<string, AgentToken> = {
     bgColor: '#FDE8E4',
     borderColor: '#C23B22',
     icon: '💰',
+    dark: { color: '#FCA5A5', bgColor: '#450A0A', borderColor: '#991B1B' },
   },
   player: {
     id: 'player',
@@ -53,6 +105,7 @@ export const KNOWN_AGENTS: Record<string, AgentToken> = {
     bgColor: '#FFF3CD',
     borderColor: '#DAA520',
     icon: '👑',
+    dark: { color: '#FDE68A', bgColor: '#422006', borderColor: '#B45309' },
   },
 };
 
@@ -95,7 +148,26 @@ export function getAgentToken(agentId: string): AgentToken {
     bgColor: scheme.bgColor,
     borderColor: scheme.borderColor,
     icon: scheme.icon,
+    dark: scheme.dark,
   };
   tokenCache.set(agentId, token);
   return token;
+}
+
+/**
+ * Returns the active colors for the current theme.
+ * Checks for `.dark` class on `<html>`.
+ */
+export function getActiveColors(token: AgentToken): {
+  color: string;
+  bgColor: string;
+  borderColor: string;
+} {
+  const isDark =
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark');
+  if (isDark && token.dark) {
+    return token.dark;
+  }
+  return { color: token.color, bgColor: token.bgColor, borderColor: token.borderColor };
 }

--- a/web/src/theme/design-tokens.css
+++ b/web/src/theme/design-tokens.css
@@ -1,0 +1,207 @@
+/*
+ * Design Tokens — CSS Custom Properties
+ * Light / Dark theme support for the imperial court simulator.
+ *
+ * Naming convention:
+ *   --color-{semantic}-{variant}
+ *   e.g. --color-surface, --color-surface-alt, --color-text, --color-border
+ */
+
+:root {
+  /* ── Surfaces ──────────────────────────────────────── */
+  --color-app-bg: #ededf0;
+  --color-app-shell: #e4e5e9;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f8fafc;       /* slate-50 */
+  --color-surface-hover: #f1f5f9;     /* slate-100 */
+  --color-surface-active: #e2e8f0;    /* slate-200 */
+  --color-surface-inset: #f8fafc;     /* for inset panels */
+
+  /* ── Text ──────────────────────────────────────────── */
+  --color-text: #1e293b;              /* slate-800 */
+  --color-text-secondary: #64748b;    /* slate-500 */
+  --color-text-muted: #94a3b8;        /* slate-400 */
+  --color-text-inverse: #ffffff;
+
+  /* ── Borders ───────────────────────────────────────── */
+  --color-border: #e2e8f0;            /* slate-200 */
+  --color-border-strong: #cbd5e1;     /* slate-300 */
+
+  /* ── Primary (blue) ────────────────────────────────── */
+  --color-primary: #2563eb;           /* blue-600 */
+  --color-primary-hover: #1d4ed8;     /* blue-700 */
+  --color-primary-soft: #eff6ff;      /* blue-50 */
+  --color-primary-text: #1d4ed8;      /* blue-700 */
+  --color-primary-border: #93c5fd;    /* blue-300 */
+
+  /* ── Accent (purple — group chat) ──────────────────── */
+  --color-accent: #9333ea;            /* purple-600 */
+  --color-accent-hover: #7e22ce;      /* purple-700 */
+  --color-accent-soft: #faf5ff;       /* purple-50 */
+  --color-accent-text: #7e22ce;       /* purple-700 */
+  --color-accent-border: #d8b4fe;     /* purple-300 */
+  --color-accent-muted: #a855f7;      /* purple-500 */
+
+  /* ── Success (emerald/green) ───────────────────────── */
+  --color-success: #059669;           /* emerald-600 */
+  --color-success-soft: #ecfdf5;      /* emerald-50 */
+  --color-success-text: #047857;      /* emerald-700 */
+  --color-success-border: #a7f3d0;    /* emerald-200 */
+  --color-success-badge-bg: #d1fae5;  /* emerald-100 */
+  --color-delta-positive: #16a34a;    /* green-600 */
+
+  /* ── Warning (amber) ───────────────────────────────── */
+  --color-warning: #d97706;           /* amber-600 */
+  --color-warning-soft: #fffbeb;      /* amber-50 */
+  --color-warning-text: #b45309;      /* amber-700 */
+  --color-warning-strong: #92400e;    /* amber-800 */
+  --color-warning-border: #fde68a;    /* amber-200 */
+  --color-warning-badge-bg: #fef3c7;  /* amber-100 */
+  --color-warning-icon: #f59e0b;      /* amber-500 */
+
+  /* ── Danger (red) ──────────────────────────────────── */
+  --color-danger: #dc2626;            /* red-600 */
+  --color-danger-soft: #fef2f2;       /* red-50 */
+  --color-danger-text: #b91c1c;       /* red-700 */
+  --color-danger-border: #fecaca;     /* red-200 */
+  --color-danger-badge-bg: #fee2e2;   /* red-100 */
+  --color-delta-negative: #dc2626;    /* red-600 */
+
+  /* ── Info (blue accents for data cards) ─────────────── */
+  --color-info-soft: #eff6ff;         /* blue-50 */
+  --color-info-text: #1d4ed8;         /* blue-700 */
+  --color-info-border: #dbeafe;       /* blue-100 */
+
+  /* ── Chat bubbles ──────────────────────────────────── */
+  --color-player-bubble: #2563eb;     /* blue-600 */
+  --color-player-meta: #bfdbfe;       /* blue-100 (for timestamps) */
+
+  /* ── Resize handle / decorative ────────────────────── */
+  --color-dot: #cbd5e1;              /* slate-300 */
+  --color-dot-active: #3b82f6;       /* blue-500 */
+  --color-dot-hover: #60a5fa;        /* blue-400 */
+
+  /* ── Overlay ───────────────────────────────────────── */
+  --color-overlay: rgba(0, 0, 0, 0.5);
+
+  /* ── Loading/status bar ────────────────────────────── */
+  --color-toast-bg: #1e293b;          /* slate-800 */
+  --color-toast-text: #ffffff;
+  --color-toast-error-bg: #dc2626;    /* red-600 */
+
+  /* ── Province semantic cards ────────────────────────── */
+  --color-province-name-bg: #faf5ff;
+  --color-province-name-border: #f3e8ff;
+  --color-province-name-text: #7e22ce;
+  --color-province-green-bg: #f0fdf4;
+  --color-province-green-border: #dcfce7;
+  --color-province-green-text: #15803d;
+  --color-province-cyan-bg: #ecfeff;
+  --color-province-cyan-border: #cffafe;
+  --color-province-cyan-text: #0e7490;
+  --color-province-orange-bg: #fff7ed;
+  --color-province-orange-border: #ffedd5;
+  --color-province-orange-text: #c2410c;
+
+  /* ── Code blocks (markdown) ────────────────────────── */
+  --color-code-bg: #e2e8f0;          /* slate-200 */
+  --color-code-text: #1e293b;        /* slate-800 */
+  --color-pre-bg: #0f172a;           /* slate-900 */
+  --color-pre-text: #f1f5f9;         /* slate-100 */
+
+  /* ── Blockquote ────────────────────────────────────── */
+  --color-quote-border: #cbd5e1;     /* slate-300 */
+  --color-quote-text: #475569;       /* slate-600 */
+}
+
+/* ── Dark Theme ──────────────────────────────────────── */
+.dark {
+  --color-app-bg: #0f172a;
+  --color-app-shell: #1e293b;
+  --color-surface: #1e293b;
+  --color-surface-alt: #334155;
+  --color-surface-hover: #475569;
+  --color-surface-active: #64748b;
+  --color-surface-inset: #0f172a;
+
+  --color-text: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-text-inverse: #0f172a;
+
+  --color-border: #334155;
+  --color-border-strong: #475569;
+
+  --color-primary: #3b82f6;
+  --color-primary-hover: #2563eb;
+  --color-primary-soft: #1e3a5f;
+  --color-primary-text: #93c5fd;
+  --color-primary-border: #1d4ed8;
+
+  --color-accent: #a855f7;
+  --color-accent-hover: #9333ea;
+  --color-accent-soft: #2e1065;
+  --color-accent-text: #d8b4fe;
+  --color-accent-border: #7e22ce;
+  --color-accent-muted: #c084fc;
+
+  --color-success: #10b981;
+  --color-success-soft: #064e3b;
+  --color-success-text: #6ee7b7;
+  --color-success-border: #065f46;
+  --color-success-badge-bg: #064e3b;
+  --color-delta-positive: #4ade80;
+
+  --color-warning: #f59e0b;
+  --color-warning-soft: #451a03;
+  --color-warning-text: #fcd34d;
+  --color-warning-strong: #fde68a;
+  --color-warning-border: #78350f;
+  --color-warning-badge-bg: #451a03;
+  --color-warning-icon: #fbbf24;
+
+  --color-danger: #ef4444;
+  --color-danger-soft: #450a0a;
+  --color-danger-text: #fca5a5;
+  --color-danger-border: #7f1d1d;
+  --color-danger-badge-bg: #450a0a;
+  --color-delta-negative: #f87171;
+
+  --color-info-soft: #1e3a5f;
+  --color-info-text: #93c5fd;
+  --color-info-border: #1e3a5f;
+
+  --color-player-bubble: #1d4ed8;
+  --color-player-meta: #1e40af;
+
+  --color-dot: #475569;
+  --color-dot-active: #3b82f6;
+  --color-dot-hover: #60a5fa;
+
+  --color-overlay: rgba(0, 0, 0, 0.7);
+
+  --color-toast-bg: #0f172a;
+  --color-toast-text: #f1f5f9;
+  --color-toast-error-bg: #991b1b;
+
+  --color-province-name-bg: #2e1065;
+  --color-province-name-border: #3b0764;
+  --color-province-name-text: #d8b4fe;
+  --color-province-green-bg: #052e16;
+  --color-province-green-border: #064e3b;
+  --color-province-green-text: #86efac;
+  --color-province-cyan-bg: #083344;
+  --color-province-cyan-border: #164e63;
+  --color-province-cyan-text: #67e8f9;
+  --color-province-orange-bg: #431407;
+  --color-province-orange-border: #7c2d12;
+  --color-province-orange-text: #fdba74;
+
+  --color-code-bg: #334155;
+  --color-code-text: #e2e8f0;
+  --color-pre-bg: #0f172a;
+  --color-pre-text: #e2e8f0;
+
+  --color-quote-border: #475569;
+  --color-quote-text: #94a3b8;
+}

--- a/web/src/theme/useTheme.ts
+++ b/web/src/theme/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { create } from 'zustand';
 
 type Theme = 'light' | 'dark';
 
@@ -15,21 +15,24 @@ function applyTheme(theme: Theme) {
   document.documentElement.classList.toggle('dark', theme === 'dark');
 }
 
-export function useTheme() {
-  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
-
-  useEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
-
-  const setTheme = useCallback((t: Theme) => {
-    localStorage.setItem(STORAGE_KEY, t);
-    setThemeState(t);
-  }, []);
-
-  const toggleTheme = useCallback(() => {
-    setTheme(theme === 'light' ? 'dark' : 'light');
-  }, [theme, setTheme]);
-
-  return { theme, setTheme, toggleTheme } as const;
+interface ThemeState {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
 }
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: getInitialTheme(),
+  setTheme: (t: Theme) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    applyTheme(t);
+    set({ theme: t });
+  },
+  toggleTheme: () => {
+    const next = get().theme === 'light' ? 'dark' : 'light';
+    get().setTheme(next);
+  },
+}));
+
+// Apply theme on initial load
+applyTheme(useThemeStore.getState().theme);

--- a/web/src/theme/useTheme.ts
+++ b/web/src/theme/useTheme.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'simu-emperor-theme';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'dark' || stored === 'light') return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => {
+    localStorage.setItem(STORAGE_KEY, t);
+    setThemeState(t);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  }, [theme, setTheme]);
+
+  return { theme, setTheme, toggleTheme } as const;
+}

--- a/web/src/utils/render.tsx
+++ b/web/src/utils/render.tsx
@@ -2,39 +2,52 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 export function renderMarkdown(content: string, isPlayer: boolean) {
-  const textTone = isPlayer ? 'text-white' : 'text-slate-700';
-  const mutedTone = isPlayer ? 'text-blue-100' : 'text-slate-500';
-  const linkTone = isPlayer ? 'text-blue-100 underline' : 'text-blue-600 underline';
-  const quoteTone = isPlayer ? 'border-blue-300 text-blue-100' : 'border-slate-300 text-slate-600';
-  const codeTone = isPlayer ? 'bg-blue-500/60 text-white' : 'bg-slate-200 text-slate-800';
-  const preTone = isPlayer ? 'bg-blue-700/70 text-blue-50' : 'bg-slate-900 text-slate-100';
+  // Player messages use hardcoded light-on-dark; agent messages use CSS vars
+  const textStyle = isPlayer
+    ? { color: 'var(--color-text-inverse)' }
+    : { color: 'var(--color-text)' };
+  const mutedStyle = isPlayer
+    ? { color: 'var(--color-player-meta)' }
+    : { color: 'var(--color-text-secondary)' };
+  const linkStyle = isPlayer
+    ? { color: 'var(--color-player-meta)', textDecoration: 'underline' as const }
+    : { color: 'var(--color-primary)', textDecoration: 'underline' as const };
+  const quoteStyle = isPlayer
+    ? { borderColor: 'var(--color-player-meta)', color: 'var(--color-player-meta)' }
+    : { borderColor: 'var(--color-quote-border)', color: 'var(--color-quote-text)' };
+  const codeStyle = isPlayer
+    ? { backgroundColor: 'rgba(59,130,246,0.4)', color: 'var(--color-text-inverse)' }
+    : { backgroundColor: 'var(--color-code-bg)', color: 'var(--color-code-text)' };
+  const preStyle = isPlayer
+    ? { backgroundColor: 'rgba(30,64,175,0.7)', color: 'var(--color-player-meta)' }
+    : { backgroundColor: 'var(--color-pre-bg)', color: 'var(--color-pre-text)' };
 
   return (
     <div className="mt-1 space-y-2 text-sm leading-6">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          p: ({ children }) => <p className={`whitespace-pre-wrap ${textTone}`}>{children}</p>,
+          p: ({ children }) => <p className="whitespace-pre-wrap" style={textStyle}>{children}</p>,
           ul: ({ children }) => (
-            <ul className={`list-disc space-y-1 pl-5 ${textTone}`}>{children}</ul>
+            <ul className="list-disc space-y-1 pl-5" style={textStyle}>{children}</ul>
           ),
           ol: ({ children }) => (
-            <ol className={`list-decimal space-y-1 pl-5 ${textTone}`}>{children}</ol>
+            <ol className="list-decimal space-y-1 pl-5" style={textStyle}>{children}</ol>
           ),
-          li: ({ children }) => <li className={textTone}>{children}</li>,
-          strong: ({ children }) => <strong className={textTone}>{children}</strong>,
-          em: ({ children }) => <em className={mutedTone}>{children}</em>,
+          li: ({ children }) => <li style={textStyle}>{children}</li>,
+          strong: ({ children }) => <strong style={textStyle}>{children}</strong>,
+          em: ({ children }) => <em style={mutedStyle}>{children}</em>,
           blockquote: ({ children }) => (
-            <blockquote className={`border-l-2 pl-3 italic ${quoteTone}`}>{children}</blockquote>
+            <blockquote className="border-l-2 pl-3 italic" style={quoteStyle}>{children}</blockquote>
           ),
           code: ({ children }) => (
-            <code className={`rounded px-1 py-0.5 text-xs ${codeTone}`}>{children}</code>
+            <code className="rounded px-1 py-0.5 text-xs" style={codeStyle}>{children}</code>
           ),
           pre: ({ children }) => (
-            <pre className={`overflow-x-auto rounded-lg p-3 text-xs ${preTone}`}>{children}</pre>
+            <pre className="overflow-x-auto rounded-lg p-3 text-xs" style={preStyle}>{children}</pre>
           ),
           a: ({ href, children }) => (
-            <a href={href} className={linkTone} target="_blank" rel="noreferrer">
+            <a href={href} style={linkStyle} target="_blank" rel="noreferrer">
               {children}
             </a>
           ),

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {
@@ -19,6 +20,33 @@ export default {
           800: '#075985',
           900: '#0c4a6e',
         },
+        // Semantic tokens mapped from CSS custom properties
+        surface: {
+          DEFAULT: 'var(--color-surface)',
+          alt: 'var(--color-surface-alt)',
+          hover: 'var(--color-surface-hover)',
+          active: 'var(--color-surface-active)',
+          inset: 'var(--color-surface-inset)',
+        },
+        'app-bg': 'var(--color-app-bg)',
+        'app-shell': 'var(--color-app-shell)',
+      },
+      textColor: {
+        skin: {
+          DEFAULT: 'var(--color-text)',
+          secondary: 'var(--color-text-secondary)',
+          muted: 'var(--color-text-muted)',
+          inverse: 'var(--color-text-inverse)',
+        },
+      },
+      borderColor: {
+        skin: {
+          DEFAULT: 'var(--color-border)',
+          strong: 'var(--color-border-strong)',
+        },
+      },
+      backgroundColor: {
+        overlay: 'var(--color-overlay)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Introduced centralized CSS custom properties design token system (`design-tokens.css`) with 70+ semantic color variables for light and dark themes
- Added `useTheme` hook with localStorage persistence + system preference fallback, and `ThemeToggle` component for instant light/dark switching
- Migrated all 28 component files from hardcoded Tailwind color classes to `var(--color-*)` inline styles, enabling theme-aware rendering without Tailwind `dark:` prefix proliferation
- Extended `agent-tokens.ts` with dark mode color variants and `getActiveColors()` runtime resolver

## Architecture
- `:root` / `.dark` class-based theming via `darkMode: 'class'` in Tailwind config
- Components use inline `style={{ color: 'var(--color-text)' }}` instead of `text-slate-700 dark:text-slate-200` — keeps token system centralized and avoids doubling color classes
- Agent identity colors resolve at render time via `getActiveColors(token)` which checks `document.documentElement.classList`

## Test plan
- [ ] Verify light mode renders identically to current production
- [ ] Toggle dark mode via bottom-right button, confirm all surfaces/text/borders adapt
- [ ] Verify agent message bubbles show correct dark palette per agent
- [ ] Check province cards, incident panels, task blocks in dark mode
- [ ] Confirm theme persists across page refresh (localStorage)
- [ ] Confirm system preference fallback works when no stored preference exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)