### PR TITLE
feat: Phase 4B data visualization — tick history + charts

### DIFF
--- a/packages/server/simu_server/engine/game_engine.py
+++ b/packages/server/simu_server/engine/game_engine.py
@@ -11,6 +11,7 @@ from simu_server.engine.incidents import IncidentSystem
 from simu_server.engine.state import GameState
 from simu_server.engine.tick import TickCoordinator
 from simu_server.stores.database import Database
+from simu_server.stores.tick_history import TickHistoryStore
 
 
 class GameEngine:
@@ -23,6 +24,7 @@ class GameEngine:
     def __init__(self, db: Database) -> None:
         self.state = GameState(db)
         self.incidents = IncidentSystem(db)
+        self.tick_history = TickHistoryStore(db)
         self.tick_coordinator = TickCoordinator(self.state, self.incidents)
         self._lock = asyncio.Lock()
 
@@ -32,7 +34,9 @@ class GameEngine:
 
     async def tick(self, session_id: str) -> TapeEvent:
         async with self._lock:
-            return await self.tick_coordinator.tick(session_id)
+            event = await self.tick_coordinator.tick(session_id)
+            await self.tick_history.save_snapshot(self.state.nation)
+            return event
 
     def query_state(self, path: str = "") -> dict[str, Any]:
         return self.state.query(path)

--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -22,6 +22,7 @@ from simu_shared.models import (
 )
 from simu_server.agents.registry import AgentRegistry
 from simu_server.config import settings
+from simu_server.stores.tick_history import TickHistoryStore
 
 router = APIRouter(prefix="/api")
 
@@ -593,6 +594,82 @@ async def get_subsessions(
             "goal": s.metadata.get("goal", ""),
         })
     return result
+
+
+# ---------------------------------------------------------------------------
+# History — tick snapshots for data visualization
+# ---------------------------------------------------------------------------
+
+
+@router.get("/history/ticks")
+async def get_tick_history(limit: int = 50) -> dict[str, Any]:
+    engine = _get("engine")
+    if engine is None:
+        return {"ticks": []}
+    history: TickHistoryStore = engine.tick_history
+    ticks = await history.get_nation_ticks(limit=limit)
+    # Enrich with active incident count from current incidents
+    incident_counts: dict[int, int] = {}
+    for row in ticks:
+        incident_counts[row["turn"]] = 0
+    # We only have current incidents; for historical counts we'd need more data.
+    # For now, set the latest turn's count from the engine.
+    if ticks:
+        active = engine.incidents.active
+        ticks[-1]["active_incident_count"] = len(active)
+    return {"ticks": ticks}
+
+
+@router.get("/history/provinces")
+async def get_province_history(province_id: str, limit: int = 50) -> dict[str, Any]:
+    engine = _get("engine")
+    if engine is None:
+        return {"province_id": province_id, "province_name": province_id, "ticks": []}
+    history: TickHistoryStore = engine.tick_history
+    return await history.get_province_ticks(province_id=province_id, limit=limit)
+
+
+@router.get("/history/comparison")
+async def get_comparison(metric: str = "population", turn: int | None = None) -> dict[str, Any]:
+    engine = _get("engine")
+    if engine is None:
+        return {"turn": 0, "metric": metric, "provinces": []}
+    history: TickHistoryStore = engine.tick_history
+    return await history.get_comparison(metric=metric, turn=turn)
+
+
+@router.get("/history/events")
+async def get_event_history(limit: int = 20) -> dict[str, Any]:
+    """Return incident creation events with their effects for timeline display."""
+    engine = _get("engine")
+    if engine is None:
+        return {"events": []}
+    db = engine.state._db
+    cursor = await db.conn.execute(
+        "SELECT incident_id, data, remaining_ticks, created_at FROM incidents ORDER BY created_at DESC LIMIT ?",
+        (limit,),
+    )
+    rows = await cursor.fetchall()
+    events: list[dict[str, Any]] = []
+    for incident_id, data_json, remaining_ticks, created_at in reversed(rows):
+        inc = json.loads(data_json)
+        effects = []
+        for eff in inc.get("effects", []):
+            effects.append({
+                "target_path": eff.get("target_path", ""),
+                "add": str(eff["add"]) if eff.get("add") is not None else None,
+                "factor": str(eff["factor"]) if eff.get("factor") is not None else None,
+            })
+        events.append({
+            "incident_id": incident_id,
+            "title": inc.get("title", ""),
+            "source": inc.get("source", "system"),
+            "effects": effects,
+            "duration_ticks": inc.get("remaining_ticks", 0),
+            "remaining_ticks": remaining_ticks,
+            "created_at": created_at,
+        })
+    return {"events": events}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/simu_server/stores/database.py
+++ b/packages/server/simu_server/stores/database.py
@@ -80,6 +80,13 @@ CREATE TABLE IF NOT EXISTS incidents (
     remaining_ticks INTEGER NOT NULL,
     created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Tick history (per-tick snapshots for data visualization)
+CREATE TABLE IF NOT EXISTS tick_history (
+    turn      INTEGER PRIMARY KEY,
+    timestamp TEXT NOT NULL,
+    snapshot  TEXT NOT NULL
+);
 """
 
 

--- a/packages/server/simu_server/stores/tick_history.py
+++ b/packages/server/simu_server/stores/tick_history.py
@@ -1,0 +1,147 @@
+"""TickHistoryStore — persists per-tick snapshots for data visualization.
+
+Each tick, a full NationData snapshot is serialized to JSON and stored.
+Query methods extract time-series, cross-province comparisons, and
+incident event timelines for the frontend charts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from simu_shared.models import NationData
+from simu_server.stores.database import Database
+
+logger = logging.getLogger(__name__)
+
+
+class TickHistoryStore:
+    """Reads and writes tick snapshots in the tick_history table."""
+
+    def __init__(self, db: Database) -> None:
+        self._db = db
+
+    async def save_snapshot(self, nation: NationData) -> None:
+        """Persist a snapshot of the current nation state for the given turn."""
+        ts = datetime.now(UTC).isoformat()
+        await self._db.conn.execute(
+            "INSERT OR REPLACE INTO tick_history (turn, timestamp, snapshot) VALUES (?, ?, ?)",
+            (nation.turn, ts, nation.model_dump_json()),
+        )
+        await self._db.conn.commit()
+
+    async def get_nation_ticks(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return nation-level time-series data (most recent *limit* ticks)."""
+        cursor = await self._db.conn.execute(
+            "SELECT turn, timestamp, snapshot FROM tick_history ORDER BY turn DESC LIMIT ?",
+            (limit,),
+        )
+        rows = await cursor.fetchall()
+        result: list[dict[str, Any]] = []
+        for turn, ts, raw in reversed(rows):  # oldest first
+            nation = json.loads(raw)
+            provinces = nation.get("provinces", {})
+            result.append({
+                "turn": turn,
+                "timestamp": ts,
+                "imperial_treasury": float(nation.get("imperial_treasury", 0)),
+                "base_tax_rate": float(nation.get("base_tax_rate", 0)),
+                "tribute_rate": float(nation.get("tribute_rate", 0)),
+                "fixed_expenditure": float(nation.get("fixed_expenditure", 0)),
+                "total_population": sum(
+                    float(p.get("population", 0)) for p in provinces.values()
+                ),
+                "total_production": sum(
+                    float(p.get("production_value", 0)) for p in provinces.values()
+                ),
+                "total_stockpile": sum(
+                    float(p.get("stockpile", 0)) for p in provinces.values()
+                ),
+                "province_count": len(provinces),
+                "active_incident_count": 0,  # filled by caller if needed
+            })
+        return result
+
+    async def get_province_ticks(
+        self, province_id: str, limit: int = 50
+    ) -> dict[str, Any]:
+        """Return time-series data for a single province."""
+        cursor = await self._db.conn.execute(
+            "SELECT turn, timestamp, snapshot FROM tick_history ORDER BY turn DESC LIMIT ?",
+            (limit,),
+        )
+        rows = await cursor.fetchall()
+        ticks: list[dict[str, Any]] = []
+        province_name = province_id
+        for turn, ts, raw in reversed(rows):
+            nation = json.loads(raw)
+            prov = nation.get("provinces", {}).get(province_id)
+            if prov is None:
+                continue
+            province_name = prov.get("name", province_id)
+            base_tax = float(nation.get("base_tax_rate", 0))
+            ticks.append({
+                "turn": turn,
+                "timestamp": ts,
+                "production_value": float(prov.get("production_value", 0)),
+                "population": float(prov.get("population", 0)),
+                "stockpile": float(prov.get("stockpile", 0)),
+                "fixed_expenditure": float(prov.get("fixed_expenditure", 0)),
+                "tax_modifier": float(prov.get("tax_modifier", 0)),
+                "base_production_growth": float(prov.get("base_production_growth", 0)),
+                "base_population_growth": float(prov.get("base_population_growth", 0)),
+                "actual_tax_rate": base_tax + float(prov.get("tax_modifier", 0)),
+            })
+        return {
+            "province_id": province_id,
+            "province_name": province_name,
+            "ticks": ticks,
+        }
+
+    async def get_comparison(
+        self, metric: str, turn: int | None = None
+    ) -> dict[str, Any]:
+        """Cross-province comparison for a given metric at a specific turn."""
+        if turn is not None:
+            cursor = await self._db.conn.execute(
+                "SELECT turn, snapshot FROM tick_history WHERE turn = ?",
+                (turn,),
+            )
+        else:
+            cursor = await self._db.conn.execute(
+                "SELECT turn, snapshot FROM tick_history ORDER BY turn DESC LIMIT 1",
+            )
+        row = await cursor.fetchone()
+        if row is None:
+            return {"turn": turn or 0, "metric": metric, "provinces": []}
+
+        actual_turn, raw = row
+        nation = json.loads(raw)
+        provinces_data = nation.get("provinces", {})
+
+        # Valid province-level numeric metrics
+        valid_metrics = {
+            "population", "production_value", "stockpile",
+            "fixed_expenditure", "tax_modifier",
+            "base_production_growth", "base_population_growth",
+        }
+        if metric not in valid_metrics:
+            return {"turn": actual_turn, "metric": metric, "provinces": []}
+
+        provinces = []
+        for pid, prov in provinces_data.items():
+            provinces.append({
+                "province_id": pid,
+                "name": prov.get("name", pid),
+                "value": float(prov.get(metric, 0)),
+            })
+        provinces.sort(key=lambda x: x["value"], reverse=True)
+
+        return {
+            "turn": actual_turn,
+            "metric": metric,
+            "provinces": provinces,
+        }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.12"
       },
@@ -971,6 +972,42 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1335,6 +1372,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1498,6 +1547,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1576,6 +1688,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -2234,6 +2352,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2363,6 +2490,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2399,6 +2647,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -2664,6 +2918,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -2744,6 +3008,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -3200,6 +3470,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3229,6 +3509,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -5377,7 +5666,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -5405,6 +5693,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -5440,6 +5751,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5452,6 +5793,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regexp.prototype.flags": {
@@ -5546,6 +5902,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -6109,6 +6471,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6423,6 +6791,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6456,6 +6833,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "zustand": "^5.0.12"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -702,6 +702,7 @@ export default function App() {
         <ChatPanel onSend={handleSend} onSendToGroup={handleSendToGroup} />
 
         <RightSidebar
+          client={client.current}
           onRefresh={() => void refreshData()}
           onFetchIncidents={fetchIncidents}
           onFetchFullState={fetchFullState}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,10 @@ import type {
   SessionStateData,
   GroupChat,
   Incident,
+  TickHistoryResponse,
+  ProvinceHistoryResponse,
+  ComparisonResponse,
+  EventHistoryResponse,
 } from './types';
 
 export interface GameClientConfig {
@@ -345,6 +349,28 @@ export class GameClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // History API — data visualization
+  // ---------------------------------------------------------------------------
+
+  async getTickHistory(limit: number = 50): Promise<TickHistoryResponse> {
+    return this.request<TickHistoryResponse>(`/history/ticks?limit=${limit}`);
+  }
+
+  async getProvinceHistory(provinceId: string, limit: number = 50): Promise<ProvinceHistoryResponse> {
+    return this.request<ProvinceHistoryResponse>(`/history/provinces?province_id=${provinceId}&limit=${limit}`);
+  }
+
+  async getComparison(metric: string = 'population', turn?: number): Promise<ComparisonResponse> {
+    const params = new URLSearchParams({ metric });
+    if (turn !== undefined) params.set('turn', String(turn));
+    return this.request<ComparisonResponse>(`/history/comparison?${params.toString()}`);
+  }
+
+  async getEventHistory(limit: number = 20): Promise<EventHistoryResponse> {
+    return this.request<EventHistoryResponse>(`/history/events?limit=${limit}`);
   }
 
   async getAgentJobStatus(taskId: string): Promise<{

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -239,3 +239,70 @@ export interface IncidentEffect {
   add: string | null;
   factor: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// History API — data visualization
+// ---------------------------------------------------------------------------
+
+export interface NationTickData {
+  turn: number;
+  timestamp: string;
+  imperial_treasury: number;
+  base_tax_rate: number;
+  tribute_rate: number;
+  fixed_expenditure: number;
+  total_population: number;
+  total_production: number;
+  total_stockpile: number;
+  province_count: number;
+  active_incident_count: number;
+}
+
+export interface TickHistoryResponse {
+  ticks: NationTickData[];
+}
+
+export interface ProvinceTickData {
+  turn: number;
+  timestamp: string;
+  production_value: number;
+  population: number;
+  stockpile: number;
+  fixed_expenditure: number;
+  tax_modifier: number;
+  base_production_growth: number;
+  base_population_growth: number;
+  actual_tax_rate: number;
+}
+
+export interface ProvinceHistoryResponse {
+  province_id: string;
+  province_name: string;
+  ticks: ProvinceTickData[];
+}
+
+export interface ComparisonProvince {
+  province_id: string;
+  name: string;
+  value: number;
+}
+
+export interface ComparisonResponse {
+  turn: number;
+  metric: string;
+  provinces: ComparisonProvince[];
+}
+
+export interface HistoryEvent {
+  incident_id: string;
+  title: string;
+  source: string;
+  effects: IncidentEffect[];
+  duration_ticks: number;
+  remaining_ticks: number;
+  created_at: string;
+}
+
+export interface EventHistoryResponse {
+  events: HistoryEvent[];
+}

--- a/web/src/components/charts/ComparisonChart.tsx
+++ b/web/src/components/charts/ComparisonChart.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+
+import type { ComparisonProvince } from '../../api/types';
+
+interface ComparisonChartProps {
+  data: ComparisonProvince[];
+  metric: string;
+  turn: number;
+  loading: boolean;
+  onMetricChange: (metric: string) => void;
+}
+
+const METRIC_OPTIONS: { value: string; label: string }[] = [
+  { value: 'population', label: '人口' },
+  { value: 'production_value', label: '产值' },
+  { value: 'stockpile', label: '库存' },
+  { value: 'fixed_expenditure', label: '固定支出' },
+  { value: 'tax_modifier', label: '税率修正' },
+];
+
+// Province color palette
+const PROVINCE_COLORS = [
+  '#2563eb', '#059669', '#d97706', '#9333ea',
+  '#dc2626', '#0891b2', '#65a30d', '#c026d3',
+];
+
+export function ComparisonChart({ data, metric, turn, loading, onMetricChange }: ComparisonChartProps) {
+  const [resolvedColors, setResolvedColors] = useState<string[]>(PROVINCE_COLORS);
+
+  useEffect(() => {
+    // Use theme-aware colors if available
+    const root = document.documentElement;
+    const style = getComputedStyle(root);
+    const primary = style.getPropertyValue('--color-primary').trim();
+    if (primary) {
+      setResolvedColors(PROVINCE_COLORS);
+    }
+  }, []);
+
+  const metricLabel = METRIC_OPTIONS.find((m) => m.value === metric)?.label || metric;
+
+  if (loading) {
+    return (
+      <div className="flex h-48 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        加载中...
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        暂无对比数据
+      </div>
+    );
+  }
+
+  const formatValue = (value: number) => {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return value.toFixed(1);
+  };
+
+  return (
+    <div>
+      {/* Metric selector */}
+      <div className="mb-2 flex items-center gap-2">
+        <select
+          value={metric}
+          onChange={(e) => onMetricChange(e.target.value)}
+          className="rounded-md px-2 py-1 text-[10px]"
+          style={{
+            borderWidth: 1,
+            borderStyle: 'solid',
+            borderColor: 'var(--color-border)',
+            backgroundColor: 'var(--color-surface)',
+            color: 'var(--color-text)',
+          }}
+        >
+          {METRIC_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+        <span className="text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+          回合 {turn}
+        </span>
+      </div>
+
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={180}>
+        <BarChart data={data} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          <XAxis
+            dataKey="name"
+            tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--color-border)' }}
+          />
+          <YAxis
+            tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--color-border)' }}
+            tickFormatter={formatValue}
+            width={45}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'var(--color-border)',
+              borderRadius: 8,
+              fontSize: 11,
+              color: 'var(--color-text)',
+            }}
+            formatter={(value) => [formatValue(Number(value)), metricLabel]}
+          />
+          <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+            {data.map((_, index) => (
+              <Cell key={index} fill={resolvedColors[index % resolvedColors.length]} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/src/components/charts/DataPanel.tsx
+++ b/web/src/components/charts/DataPanel.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type {
+  NationTickData,
+  ComparisonProvince,
+  HistoryEvent,
+} from '../../api/types';
+import { GameClient } from '../../api/client';
+import { TrendChart } from './TrendChart';
+import { ComparisonChart } from './ComparisonChart';
+import { EventTimeline } from './EventTimeline';
+
+interface DataPanelProps {
+  client: GameClient;
+}
+
+export function DataPanel({ client }: DataPanelProps) {
+  const [ticks, setTicks] = useState<NationTickData[]>([]);
+  const [comparison, setComparison] = useState<ComparisonProvince[]>([]);
+  const [comparisonTurn, setComparisonTurn] = useState(0);
+  const [comparisonMetric, setComparisonMetric] = useState('population');
+  const [events, setEvents] = useState<HistoryEvent[]>([]);
+
+  const [loadingTicks, setLoadingTicks] = useState(true);
+  const [loadingComparison, setLoadingComparison] = useState(true);
+  const [loadingEvents, setLoadingEvents] = useState(true);
+
+  const mountedRef = useRef(true);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      setLoadingTicks(true);
+      setLoadingComparison(true);
+      setLoadingEvents(true);
+
+      const [tickRes, compRes, eventRes] = await Promise.all([
+        client.getTickHistory(50),
+        client.getComparison(comparisonMetric),
+        client.getEventHistory(20),
+      ]);
+
+      if (!mountedRef.current) return;
+
+      setTicks(tickRes.ticks);
+      setComparison(compRes.provinces);
+      setComparisonTurn(compRes.turn);
+      setEvents(eventRes.events);
+    } catch {
+      // Silently handle — data will show empty state
+    } finally {
+      if (mountedRef.current) {
+        setLoadingTicks(false);
+        setLoadingComparison(false);
+        setLoadingEvents(false);
+      }
+    }
+  }, [client, comparisonMetric]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    fetchAll();
+    return () => { mountedRef.current = false; };
+  }, [fetchAll]);
+
+  // Refresh when a tick event arrives via WebSocket
+  useEffect(() => {
+    const off = client.on('event', (data: unknown) => {
+      const evt = data as Record<string, unknown> | null;
+      if (evt && evt.event_type === 'tick_completed') {
+        fetchAll();
+      }
+    });
+    return off;
+  }, [client, fetchAll]);
+
+  const handleMetricChange = useCallback(async (metric: string) => {
+    setComparisonMetric(metric);
+    setLoadingComparison(true);
+    try {
+      const res = await client.getComparison(metric);
+      if (mountedRef.current) {
+        setComparison(res.provinces);
+        setComparisonTurn(res.turn);
+      }
+    } catch {
+      // keep previous data
+    } finally {
+      if (mountedRef.current) setLoadingComparison(false);
+    }
+  }, [client]);
+
+  return (
+    <div className="space-y-4">
+      {/* Trend chart */}
+      <section>
+        <h3 className="mb-1 text-xs font-semibold" style={{ color: 'var(--color-text)' }}>
+          趋势变化
+        </h3>
+        <TrendChart data={ticks} loading={loadingTicks} />
+      </section>
+
+      {/* Province comparison */}
+      <section>
+        <h3 className="mb-1 text-xs font-semibold" style={{ color: 'var(--color-text)' }}>
+          省份对比
+        </h3>
+        <ComparisonChart
+          data={comparison}
+          metric={comparisonMetric}
+          turn={comparisonTurn}
+          loading={loadingComparison}
+          onMetricChange={handleMetricChange}
+        />
+      </section>
+
+      {/* Event timeline */}
+      <section>
+        <h3 className="mb-1 text-xs font-semibold" style={{ color: 'var(--color-text)' }}>
+          事件时间线
+        </h3>
+        <EventTimeline events={events} loading={loadingEvents} />
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/charts/EventTimeline.tsx
+++ b/web/src/components/charts/EventTimeline.tsx
@@ -1,0 +1,107 @@
+import { AlertTriangle } from 'lucide-react';
+
+import type { HistoryEvent } from '../../api/types';
+
+interface EventTimelineProps {
+  events: HistoryEvent[];
+  loading: boolean;
+}
+
+function formatEffect(effect: { target_path: string; add: string | null; factor: string | null }): string {
+  const path = effect.target_path.split('.').pop() || effect.target_path;
+  if (effect.add !== null) {
+    const val = parseFloat(effect.add);
+    return `${path} ${val >= 0 ? '+' : ''}${val}`;
+  }
+  if (effect.factor !== null) {
+    const pct = (parseFloat(effect.factor) * 100).toFixed(1);
+    const val = parseFloat(effect.factor);
+    return `${path} ${val >= 0 ? '+' : ''}${pct}%`;
+  }
+  return path;
+}
+
+export function EventTimeline({ events, loading }: EventTimelineProps) {
+  if (loading) {
+    return (
+      <div className="flex h-32 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        加载中...
+      </div>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <div className="flex h-32 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        暂无历史事件
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {events.map((event) => {
+        const isActive = event.remaining_ticks > 0;
+        return (
+          <div
+            key={event.incident_id}
+            className="rounded-lg p-2"
+            style={{
+              borderWidth: 1,
+              borderStyle: 'solid',
+              borderColor: isActive ? 'var(--color-danger-border)' : 'var(--color-border)',
+              backgroundColor: isActive ? 'var(--color-danger-soft)' : 'var(--color-surface-alt)',
+            }}
+          >
+            <div className="flex items-start gap-1.5">
+              <AlertTriangle
+                className="mt-0.5 h-3 w-3 flex-shrink-0"
+                style={{ color: isActive ? 'var(--color-danger)' : 'var(--color-text-muted)' }}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center justify-between gap-1">
+                  <p className="truncate text-xs font-medium" style={{ color: 'var(--color-text)' }}>
+                    {event.title}
+                  </p>
+                  <span
+                    className="flex-shrink-0 rounded px-1 py-0.5 text-[10px]"
+                    style={{
+                      backgroundColor: isActive ? 'var(--color-danger-badge-bg)' : 'var(--color-surface-active)',
+                      color: isActive ? 'var(--color-danger-text)' : 'var(--color-text-secondary)',
+                    }}
+                  >
+                    {isActive ? `剩余 ${event.remaining_ticks} 回合` : '已结束'}
+                  </span>
+                </div>
+                <p className="mt-0.5 text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+                  来源: {event.source} · 持续 {event.duration_ticks} 回合
+                </p>
+                {event.effects.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {event.effects.map((eff, i) => {
+                      const isNegative =
+                        (eff.add !== null && parseFloat(eff.add) < 0) ||
+                        (eff.factor !== null && parseFloat(eff.factor) < 0);
+                      return (
+                        <span
+                          key={i}
+                          className="rounded px-1 py-0.5 text-[10px]"
+                          style={{
+                            backgroundColor: isNegative ? 'var(--color-danger-soft)' : 'var(--color-success-soft)',
+                            color: isNegative ? 'var(--color-danger-text)' : 'var(--color-success-text)',
+                          }}
+                        >
+                          {formatEffect(eff)}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/charts/TrendChart.tsx
+++ b/web/src/components/charts/TrendChart.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+
+import type { NationTickData } from '../../api/types';
+
+interface TrendChartProps {
+  data: NationTickData[];
+  loading: boolean;
+}
+
+type MetricKey = 'imperial_treasury' | 'total_population' | 'total_production' | 'total_stockpile';
+
+const METRICS: { key: MetricKey; label: string; color: string }[] = [
+  { key: 'imperial_treasury', label: '国库', color: 'var(--color-warning)' },
+  { key: 'total_population', label: '总人口', color: 'var(--color-primary)' },
+  { key: 'total_production', label: '总产值', color: 'var(--color-success)' },
+  { key: 'total_stockpile', label: '总库存', color: 'var(--color-accent)' },
+];
+
+export function TrendChart({ data, loading }: TrendChartProps) {
+  const [activeMetrics, setActiveMetrics] = useState<Set<MetricKey>>(
+    new Set(['imperial_treasury', 'total_population'])
+  );
+
+  const toggleMetric = (key: MetricKey) => {
+    setActiveMetrics((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        if (next.size > 1) next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  // Resolve CSS var colors to actual hex at render time
+  const [resolvedColors, setResolvedColors] = useState<Record<string, string>>({});
+  useEffect(() => {
+    const root = document.documentElement;
+    const style = getComputedStyle(root);
+    const colors: Record<string, string> = {};
+    for (const m of METRICS) {
+      const varName = m.color.replace('var(', '').replace(')', '');
+      colors[m.key] = style.getPropertyValue(varName).trim() || m.color;
+    }
+    setResolvedColors(colors);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex h-48 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        加载中...
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-xs" style={{ color: 'var(--color-text-secondary)' }}>
+        暂无历史数据，执行 tick 后将显示趋势图
+      </div>
+    );
+  }
+
+  const formatValue = (value: number) => {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return value.toFixed(0);
+  };
+
+  return (
+    <div>
+      {/* Metric toggles */}
+      <div className="mb-2 flex flex-wrap gap-1.5">
+        {METRICS.map((m) => {
+          const isActive = activeMetrics.has(m.key);
+          return (
+            <button
+              key={m.key}
+              type="button"
+              onClick={() => toggleMetric(m.key)}
+              className="rounded-md px-2 py-0.5 text-[10px] font-medium transition-opacity"
+              style={{
+                borderWidth: 1,
+                borderStyle: 'solid',
+                borderColor: isActive ? (resolvedColors[m.key] || m.color) : 'var(--color-border)',
+                backgroundColor: isActive ? 'var(--color-surface-alt)' : 'var(--color-surface)',
+                color: isActive ? (resolvedColors[m.key] || m.color) : 'var(--color-text-muted)',
+                opacity: isActive ? 1 : 0.6,
+              }}
+            >
+              {m.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={200}>
+        <LineChart data={data} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+          <XAxis
+            dataKey="turn"
+            tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--color-border)' }}
+            label={{ value: '回合', position: 'insideBottomRight', offset: -5, fontSize: 10, fill: 'var(--color-text-muted)' }}
+          />
+          <YAxis
+            tick={{ fontSize: 10, fill: 'var(--color-text-secondary)' }}
+            tickLine={false}
+            axisLine={{ stroke: 'var(--color-border)' }}
+            tickFormatter={formatValue}
+            width={45}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'var(--color-surface)',
+              borderColor: 'var(--color-border)',
+              borderRadius: 8,
+              fontSize: 11,
+              color: 'var(--color-text)',
+            }}
+            formatter={(value, name) => {
+              const metric = METRICS.find((m) => m.key === name);
+              return [formatValue(Number(value)), metric?.label || String(name)];
+            }}
+            labelFormatter={(turn) => `回合 ${turn}`}
+          />
+          <Legend
+            wrapperStyle={{ fontSize: 10 }}
+            formatter={(value: string) => {
+              const metric = METRICS.find((m) => m.key === value);
+              return metric?.label || value;
+            }}
+          />
+          {METRICS.filter((m) => activeMetrics.has(m.key)).map((m) => (
+            <Line
+              key={m.key}
+              type="monotone"
+              dataKey={m.key}
+              stroke={resolvedColors[m.key] || m.color}
+              strokeWidth={2}
+              dot={{ r: 2 }}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/web/src/components/layout/RightSidebar.tsx
+++ b/web/src/components/layout/RightSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  BarChart3,
   CalendarClock,
   ChevronDown,
   ChevronRight,
@@ -8,6 +9,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
+import type { GameClient } from '../../api/client';
 import { useEmpireStore } from '../../stores/empireStore';
 import { useAgentStore } from '../../stores/agentStore';
 import { useChatStore } from '../../stores/chatStore';
@@ -18,9 +20,11 @@ import { OverviewPanel } from '../empire/OverviewPanel';
 import { IncidentPanel } from '../empire/IncidentPanel';
 import { ProvincePanel } from '../empire/ProvincePanel';
 import { IncidentDetailDialog } from '../empire/IncidentDetailDialog';
+import { DataPanel } from '../charts/DataPanel';
 import { VerticalResizeHandle } from './VerticalResizeHandle';
 
 interface RightSidebarProps {
+  client: GameClient;
   onRefresh: () => void;
   onFetchIncidents: () => void;
   onFetchFullState: () => void;
@@ -30,6 +34,7 @@ interface RightSidebarProps {
 }
 
 export function RightSidebar({
+  client,
   onRefresh,
   onFetchIncidents,
   onFetchFullState,
@@ -126,6 +131,15 @@ export function RightSidebar({
             >
               省份概况
             </button>
+            <button
+              type="button"
+              onClick={() => setCurrentPanelTab('data')}
+              className="flex items-center gap-1 rounded-md px-2 py-1 font-medium"
+              style={tabClass(currentPanelTab === 'data')}
+            >
+              <BarChart3 className="h-3 w-3" />
+              数据
+            </button>
           </div>
         </div>
 
@@ -134,6 +148,11 @@ export function RightSidebar({
           {currentPanelTab === 'overview' && <OverviewPanel />}
           {currentPanelTab === 'incidents' && <IncidentPanel />}
           {currentPanelTab === 'province' && <ProvincePanel />}
+          {currentPanelTab === 'data' && (
+            <div className="h-full overflow-y-auto px-4 py-3">
+              <DataPanel client={client} />
+            </div>
+          )}
         </div>
 
         <VerticalResizeHandle

--- a/web/src/stores/empireStore.ts
+++ b/web/src/stores/empireStore.ts
@@ -13,7 +13,7 @@ interface EmpireState {
   fullState: GameStateResponse | null;
   incidents: Incident[];
   selectedProvinceId: string;
-  currentPanelTab: 'overview' | 'incidents' | 'province';
+  currentPanelTab: 'overview' | 'incidents' | 'province' | 'data';
   selectedIncident: Incident | null;
   refreshing: boolean;
 
@@ -22,7 +22,7 @@ interface EmpireState {
   setFullState: (state: GameStateResponse | null) => void;
   setIncidents: (incidents: Incident[]) => void;
   setSelectedProvinceId: (id: string) => void;
-  setCurrentPanelTab: (tab: 'overview' | 'incidents' | 'province') => void;
+  setCurrentPanelTab: (tab: 'overview' | 'incidents' | 'province' | 'data') => void;
   setSelectedIncident: (incident: Incident | null) => void;
   setRefreshing: (refreshing: boolean) => void;
 }


### PR DESCRIPTION
## Summary

- **Backend**: New `tick_history` table stores per-tick NationData snapshots. `TickHistoryStore` saves snapshot after each tick. 4 new REST endpoints: `/api/history/ticks`, `/api/history/provinces`, `/api/history/comparison`, `/api/history/events`.
- **Frontend**: Install `recharts`. Add `TrendChart` (multi-metric line chart), `ComparisonChart` (cross-province bar chart), `EventTimeline` (incident history with effect badges), `DataPanel` (container). New "数据" tab in RightSidebar.
- Auto-refreshes charts when `tick_completed` event arrives via WebSocket.

## New API endpoints

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/history/ticks?limit=50` | Nation-level time-series |
| GET | `/api/history/provinces?province_id=zhili&limit=50` | Province-level time-series |
| GET | `/api/history/comparison?metric=population&turn=5` | Cross-province comparison |
| GET | `/api/history/events?limit=20` | Incident event timeline |

## Test plan

- [ ] Run backend and verify `tick_history` table created on startup
- [ ] Execute a few ticks, confirm snapshot rows in tick_history table
- [ ] Verify `/api/history/ticks` returns correct time-series data
- [ ] Verify `/api/history/provinces?province_id=zhili` returns province data
- [ ] Verify `/api/history/comparison?metric=population` returns ranked provinces
- [ ] Verify `/api/history/events` returns incident history
- [ ] Frontend: click "数据" tab in right sidebar, verify charts render
- [ ] Frontend: execute tick, verify charts auto-refresh
- [ ] Verify dark mode compatibility (CSS var theming)
- [ ] `npx tsc --noEmit` passes, `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)