### PR TITLE
fix: MCP endpoints 404 — agents crash on startup

### DIFF
--- a/packages/server/simu_server/app.py
+++ b/packages/server/simu_server/app.py
@@ -221,8 +221,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     heartbeat_task = asyncio.create_task(_heartbeat_checker())
 
-    logger.info("Server started on %s:%d", settings.host, settings.port)
-    yield
+    # Start MCP session managers (their lifespans are not invoked by
+    # Starlette when mounted as sub-apps, so we run them manually).
+    simu_sm = simu_mcp.session_manager
+    role_sm = role_mcp.session_manager
+    async with simu_sm.run(), role_sm.run():
+        logger.info("Server started on %s:%d", settings.host, settings.port)
+        yield
 
     # Shutdown
     heartbeat_task.cancel()

--- a/packages/server/simu_server/mcp/role_mcp.py
+++ b/packages/server/simu_server/mcp/role_mcp.py
@@ -39,7 +39,7 @@ def _get(name: str) -> Any:
 # FastMCP server instance
 # ---------------------------------------------------------------------------
 
-role_mcp = FastMCP("role-mcp")
+role_mcp = FastMCP("role-mcp", streamable_http_path="/")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/simu_server/mcp/simu_mcp.py
+++ b/packages/server/simu_server/mcp/simu_mcp.py
@@ -49,7 +49,7 @@ def _get(name: str) -> Any:
 # FastMCP server instance
 # ---------------------------------------------------------------------------
 
-simu_mcp = FastMCP("simu-mcp")
+simu_mcp = FastMCP("simu-mcp", streamable_http_path="/")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- All agents crash on startup with `McpError: Session terminated` because MCP endpoints return 307→404
- **Root cause**: `FastMCP.streamable_http_app()` defaults to creating a route at `/mcp`. When mounted via `app.mount("/mcp/simu", ...)`, the full path becomes `/mcp/simu/mcp`, but agents connect to `/mcp/simu`
- **Fix**: Set `streamable_http_path="/"` on both `simu_mcp` and `role_mcp` FastMCP instances so the sub-app route is `/`, matching the mount point

## Test plan
- [ ] Start server with `python -m simu_server`
- [ ] Verify agents register successfully (no 307/404 in logs)
- [ ] Verify MCP tool calls work (send a message via frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)