### PR TITLE
fix: MemoryRetriever API mismatch + CancelledError agent crash

### DIFF
--- a/packages/sdk/simu_sdk/framework/agent.py
+++ b/packages/sdk/simu_sdk/framework/agent.py
@@ -380,6 +380,9 @@ class SimuAgent:
                 break
             try:
                 await self.on_event(event)
+            except asyncio.CancelledError:
+                logger.warning("Event processing cancelled for %s", event.event_id)
+                await self.mcp.report_error(event, RuntimeError("event processing cancelled"))
             except Exception as exc:
                 logger.exception("Error handling event %s", event.event_id)
                 await self.mcp.report_error(event, exc)

--- a/packages/sdk/simu_sdk/framework/plugins/memory_plugin.py
+++ b/packages/sdk/simu_sdk/framework/plugins/memory_plugin.py
@@ -32,7 +32,7 @@ class SimuMemoryPlugin:
             return {}
 
         try:
-            memories = await self._retriever.search(content, max_results=5)
+            memories = await self._retriever.search(content, session_id, max_views=5)
             return {"relevant_memories": memories}
         except Exception:
             logger.warning("Memory retrieval failed", exc_info=True)

--- a/packages/sdk/simu_sdk/mcp_client.py
+++ b/packages/sdk/simu_sdk/mcp_client.py
@@ -10,6 +10,7 @@ Lifecycle operations (register, heartbeat, SSE) remain on ServerClient.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -60,7 +61,7 @@ class _MCPSession:
 
     async def open(self) -> None:
         """Establish the MCP session."""
-        transport_cm = streamablehttp_client(self._url, headers=self._headers)
+        transport_cm = streamablehttp_client(self._url, headers=self._headers, timeout=120)
         read, write, _ = await transport_cm.__aenter__()
         self._contexts.append(transport_cm)
         session_cm = ClientSession(read, write)
@@ -92,6 +93,14 @@ class _MCPSession:
 
             try:
                 return await self._session.call_tool(tool, args)
+            except asyncio.CancelledError:
+                # CancelledError (BaseException) can escape from anyio cancel
+                # scopes inside the MCP transport when the HTTP request times
+                # out.  Treat it as a connection failure and try to reconnect.
+                logger.warning("MCP call cancelled for %s, reconnecting...", tool)
+                await self.close()
+                if attempt == _MAX_RECONNECT_ATTEMPTS - 1:
+                    raise
             except Exception:
                 logger.warning("MCP call failed for %s, reconnecting...", tool)
                 await self.close()
@@ -185,7 +194,7 @@ class MCPServerClient:
                 "parent_event_id": event.parent_event_id,
                 "route": route,
             })
-        except Exception:
+        except (Exception, asyncio.CancelledError):
             logger.warning("Failed to push tape event via MCP", exc_info=True)
 
     async def create_task_session(


### PR DESCRIPTION
## Summary

Fixes two bugs discovered in `backend-20260419-132858.err.log`:

- **Bug 1 — `MemoryRetriever.search()` API mismatch**: `memory_plugin.py:35` called `search(content, max_results=5)` but `MemoryRetriever.search()` signature is `(query, current_session_id, max_sessions, max_views)`. Missing required `current_session_id` and wrong keyword arg. Fixed to `search(content, session_id, max_views=5)`.

- **Bug 2 — `CancelledError` crashes agent**: `asyncio.CancelledError` is a `BaseException` (not `Exception`) in Python 3.9+. MCP transport timeouts raise `CancelledError` via anyio cancel scopes, which escaped all `except Exception` handlers in `call_tool()`, `push_tape_event()`, and `_event_loop()`, fatally crashing `governor_jiangnan`. Fixed by adding explicit `CancelledError` handling at all three levels, plus increasing httpx timeout from 30s → 120s.

## Files changed (3)

- `packages/sdk/simu_sdk/framework/plugins/memory_plugin.py` — fix search() call
- `packages/sdk/simu_sdk/mcp_client.py` — catch CancelledError, increase timeout
- `packages/sdk/simu_sdk/framework/agent.py` — catch CancelledError in event loop

## Test plan

- [ ] Start server + agents, verify no `MemoryRetriever.search()` TypeError in logs
- [ ] Verify agents survive MCP transport disruptions without crashing
- [ ] Verify memory retrieval returns relevant results during message processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)