### PR TITLE
fix: prevent duplicate task execution after task session completion

### DIFF
--- a/packages/sdk/simu_sdk/framework/agent.py
+++ b/packages/sdk/simu_sdk/framework/agent.py
@@ -245,13 +245,14 @@ class SimuAgent:
 
     async def _run_pipeline(self, event: TapeEvent) -> None:
         """Run the Bub pipeline for a single event."""
-        prev_active = self.session_state.get_active_session()
         await self._framework.process_inbound(event)
 
-        # Detect if a tool created a new task session during the pipeline
-        new_active = self.session_state.get_active_session()
-        if new_active and new_active != prev_active:
-            await self._enter_task_session(event, new_active)
+        # Check if create_task_session signaled a new task to enter.
+        # Only create_task_session sets pending_enter; finish/fail do NOT,
+        # so backward switches (returning to parent) are correctly ignored.
+        pending_task = self.session_state.consume_pending_enter()
+        if pending_task:
+            await self._enter_task_session(event, pending_task)
 
     async def _drain_queue(self, session: SessionState) -> None:
         """Process queued messages one by one while session stays idle."""

--- a/packages/sdk/simu_sdk/tools/standard.py
+++ b/packages/sdk/simu_sdk/tools/standard.py
@@ -266,6 +266,7 @@ class StandardTools:
 
         # Switch context to the new task session
         self._session_state.set_active_session(task_session_id)
+        self._session_state.set_pending_enter(task_session_id)
 
         logger.info(
             "Created task session %s (parent=%s, depth=%d, goal=%s)",
@@ -394,6 +395,7 @@ class SessionStateManager:
         self._depths: dict[str, int] = {}  # session_id → depth (0 for root)
         self._goals: dict[str, str] = {}  # task_session_id → goal description
         self._active_session: str | None = None
+        self._pending_enter: str | None = None  # task session to enter after pipeline
 
     def is_blocked(self, session_id: str) -> bool:
         """Check if a session is blocked (has pending tasks or replies)."""
@@ -475,3 +477,15 @@ class SessionStateManager:
 
     def get_active_session(self) -> str | None:
         return self._active_session
+
+    # -- Pending task entry (set by create_task_session, consumed by _run_pipeline) --
+
+    def set_pending_enter(self, task_session_id: str) -> None:
+        """Signal that a new task session should be entered after pipeline completes."""
+        self._pending_enter = task_session_id
+
+    def consume_pending_enter(self) -> str | None:
+        """Return and clear the pending task session ID, if any."""
+        task_id = getattr(self, "_pending_enter", None)
+        self._pending_enter = None
+        return task_id

--- a/packages/server/simu_server/mcp/simu_mcp.py
+++ b/packages/server/simu_server/mcp/simu_mcp.py
@@ -363,6 +363,11 @@ async def finish_task_session(
     new_status = SessionStatus.COMPLETED if status == "completed" else SessionStatus.FAILED
     await sm.update_status(task_session_id, new_status)
 
+    # Retrieve task metadata for enriched summary
+    task_session = await sm.get(task_session_id)
+    task_meta = task_session.metadata if task_session else {}
+    goal = task_meta.get("goal", "")
+
     event_type = EventType.TASK_FINISHED if status == "completed" else EventType.TASK_FAILED
     finish_msg = RoutedMessage(
         session_id=parent_session_id,
@@ -382,6 +387,7 @@ async def finish_task_session(
                 "content": result,
                 "task_session_id": task_session_id,
                 "status": status,
+                "goal": goal,
             },
             session_id=parent_session_id,
         )


### PR DESCRIPTION
## Summary

- **Root cause**: `_run_pipeline` compared active session before/after pipeline execution. When `finish_task_session` switched back to the parent, this was misinterpreted as a *forward* switch (create → task), causing `_enter_task_session` to fire with the parent session ID — replaying the completed task's logic in the parent session.
- **Fix**: Replace the before/after session comparison with an explicit `pending_enter` flag on `SessionStateManager`. Only `create_task_session` sets it; `finish_task_session` and `fail_task_session` do not. `_run_pipeline` consumes and clears the flag, so backward switches are correctly ignored.
- **Enhancement**: Enrich `task_finished` / `task_failed` event payloads with the task's `goal` from session metadata, giving the parent session richer context about what was completed.

### Files changed
| File | Change |
|------|--------|
| `packages/sdk/simu_sdk/framework/agent.py` | Replace active-session diff with `consume_pending_enter()` |
| `packages/sdk/simu_sdk/tools/standard.py` | Add `set_pending_enter` / `consume_pending_enter` to `SessionStateManager`; call `set_pending_enter` in `create_task_session` |
| `packages/server/simu_server/mcp/simu_mcp.py` | Include `goal` in `task_finished` / `task_failed` event payload |

## Test plan
- [ ] Verify task session creation → execution → finish no longer replays in parent session
- [ ] Verify nested task sessions still work correctly
- [ ] Verify `task_finished` event payload includes `goal` field
- [ ] Verify `fail_task_session` does not trigger duplicate execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)