### PR TITLE
feat: agent detail dialog (soul + data_scope)

### DIFF
--- a/packages/server/simu_server/routes/client.py
+++ b/packages/server/simu_server/routes/client.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import json
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import yaml
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import BaseModel
 
 from simu_shared.constants import EventType
@@ -346,6 +348,43 @@ async def list_agents() -> list[dict[str, Any]]:
         }
         for a in agents
     ]
+
+
+@router.get("/agents/{agent_id}")
+async def get_agent_detail(agent_id: str) -> dict[str, Any]:
+    registry: AgentRegistry | None = _get("agent_registry")
+    if registry is None:
+        raise HTTPException(status_code=503, detail="agent_registry not available")
+    agent: AgentRegistration | None = await registry.get(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    timeout = settings.agent_heartbeat_timeout
+
+    # Read soul.md
+    soul_content = ""
+    for base in (settings.default_agents_dir, settings.agents_dir):
+        soul_path: Path = base / agent_id / "soul.md"
+        if soul_path.exists():
+            soul_content = soul_path.read_text(encoding="utf-8")
+            break
+
+    # Read data_scope.yaml
+    data_scope: dict[str, Any] = {}
+    for base in (settings.default_agents_dir, settings.agents_dir):
+        scope_path: Path = base / agent_id / "data_scope.yaml"
+        if scope_path.exists():
+            data_scope = yaml.safe_load(scope_path.read_text(encoding="utf-8")) or {}
+            break
+
+    return {
+        "agent_id": agent.agent_id,
+        "agent_name": agent.display_name or agent.agent_id,
+        "status": agent.status.value,
+        "is_online": AgentRegistry.is_agent_online(agent, timeout),
+        "soul": soul_content,
+        "data_scope": data_scope,
+    }
 
 
 @router.post("/agents/generate")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -697,6 +697,7 @@ export default function App() {
           onSelectGroup={handleSelectGroup}
           onCreateGroup={handleCreateGroup}
           onAddAgent={handleAddAgent}
+          onFetchAgentDetail={(agentId) => client.current.getAgentDetail(agentId)}
         />
 
         <ChatPanel onSend={handleSend} onSendToGroup={handleSendToGroup} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   HealthResponse,
   AgentsResponse,
   AgentInfo,
+  AgentDetail,
   GameStateResponse,
   EmpireOverview,
   SessionsResponse,
@@ -241,6 +242,10 @@ export class GameClient {
     };
 
     return normalize(raw);
+  }
+
+  async getAgentDetail(agentId: string): Promise<AgentDetail> {
+    return this.request<AgentDetail>(`/agents/${encodeURIComponent(agentId)}`);
   }
 
   async healthCheck(): Promise<HealthResponse> {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -97,6 +97,11 @@ export interface AgentStatusData {
   is_online: boolean;
 }
 
+export interface AgentDetail extends AgentInfo {
+  soul: string;
+  data_scope: Record<string, unknown>;
+}
+
 export type AgentsResponse = AgentInfo[];
 
 // V4 游戏状态响应（扁平结构）

--- a/web/src/components/agents/AgentDetailDialog.tsx
+++ b/web/src/components/agents/AgentDetailDialog.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import { X, User, Shield } from 'lucide-react';
+
+import type { AgentDetail } from '../../api/types';
+import { renderMarkdown } from '../../utils/render';
+
+interface AgentDetailDialogProps {
+  agentId: string;
+  agentName: string;
+  fetchDetail: (agentId: string) => Promise<AgentDetail>;
+  onClose: () => void;
+}
+
+export function AgentDetailDialog({ agentId, agentName, fetchDetail, onClose }: AgentDetailDialogProps) {
+  const [detail, setDetail] = useState<AgentDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<'soul' | 'scope'>('soul');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchDetail(agentId)
+      .then((d) => {
+        if (!cancelled) setDetail(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [agentId, fetchDetail]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'var(--color-overlay)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg max-h-[80vh] flex flex-col rounded-2xl shadow-xl"
+        style={{ backgroundColor: 'var(--color-surface)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4" style={{ borderBottomWidth: 1, borderBottomColor: 'var(--color-border)', borderBottomStyle: 'solid' }}>
+          <div className="flex items-center gap-2">
+            <User className="h-5 w-5" style={{ color: 'var(--color-primary)' }} />
+            <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text)' }}>{agentName}</h3>
+            <span className="rounded-md px-1.5 py-0.5 text-[10px] font-mono" style={{ backgroundColor: 'var(--color-surface-alt)', color: 'var(--color-text-secondary)' }}>
+              {agentId}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg p-1 hover:opacity-80"
+            style={{ color: 'var(--color-text-muted)' }}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Tab bar */}
+        <div className="flex px-6 pt-3 gap-1">
+          <button
+            type="button"
+            onClick={() => setActiveTab('soul')}
+            className="flex items-center gap-1.5 rounded-t-lg px-3 py-1.5 text-xs font-medium"
+            style={{
+              backgroundColor: activeTab === 'soul' ? 'var(--color-primary-soft)' : 'transparent',
+              color: activeTab === 'soul' ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+              borderWidth: 1,
+              borderBottomWidth: 0,
+              borderStyle: 'solid',
+              borderColor: activeTab === 'soul' ? 'var(--color-primary-border)' : 'transparent',
+            }}
+          >
+            <User className="h-3.5 w-3.5" />
+            Soul
+          </button>
+          <button
+            type="button"
+            onClick={() => setActiveTab('scope')}
+            className="flex items-center gap-1.5 rounded-t-lg px-3 py-1.5 text-xs font-medium"
+            style={{
+              backgroundColor: activeTab === 'scope' ? 'var(--color-primary-soft)' : 'transparent',
+              color: activeTab === 'scope' ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+              borderWidth: 1,
+              borderBottomWidth: 0,
+              borderStyle: 'solid',
+              borderColor: activeTab === 'scope' ? 'var(--color-primary-border)' : 'transparent',
+            }}
+          >
+            <Shield className="h-3.5 w-3.5" />
+            Data Scope
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {loading && (
+            <div className="flex items-center justify-center py-8">
+              <span className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>加载中...</span>
+            </div>
+          )}
+          {error && (
+            <div className="rounded-lg p-3 text-sm" style={{ backgroundColor: 'var(--color-alert-error-bg)', color: 'var(--color-alert-error-text)' }}>
+              {error}
+            </div>
+          )}
+          {!loading && !error && detail && activeTab === 'soul' && (
+            detail.soul ? (
+              renderMarkdown(detail.soul, false)
+            ) : (
+              <div className="py-8 text-center text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+                暂无 Soul 配置
+              </div>
+            )
+          )}
+          {!loading && !error && detail && activeTab === 'scope' && (
+            detail.data_scope && Object.keys(detail.data_scope).length > 0 ? (
+              <div className="space-y-3">
+                {Object.entries(detail.data_scope).map(([key, value]) => (
+                  <div key={key} className="rounded-lg p-3" style={{ backgroundColor: 'var(--color-surface-alt)' }}>
+                    <div className="mb-1 text-xs font-semibold" style={{ color: 'var(--color-text-secondary)' }}>
+                      {key}
+                    </div>
+                    <div className="text-sm font-mono" style={{ color: 'var(--color-text)' }}>
+                      {Array.isArray(value) ? (
+                        <div className="flex flex-wrap gap-1">
+                          {(value as string[]).map((item, i) => (
+                            <span key={i} className="rounded px-1.5 py-0.5 text-xs" style={{ backgroundColor: 'var(--color-surface)', borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid' }}>
+                              {String(item)}
+                            </span>
+                          ))}
+                        </div>
+                      ) : typeof value === 'object' && value !== null ? (
+                        <pre className="overflow-x-auto text-xs whitespace-pre-wrap" style={{ color: 'var(--color-text)' }}>
+                          {JSON.stringify(value, null, 2)}
+                        </pre>
+                      ) : (
+                        <span>{String(value)}</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="py-8 text-center text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+                暂无 Data Scope 配置
+              </div>
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layout/LeftSidebar.tsx
+++ b/web/src/components/layout/LeftSidebar.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDown,
   ChevronRight,
+  Info,
   MessageSquare,
   MoreVertical,
   Plus,
@@ -10,10 +11,11 @@ import {
 import { useEffect, useRef, useState } from 'react';
 
 import { useAgentStore } from '../../stores/agentStore';
-import type { GroupChat } from '../../api/types';
+import type { AgentDetail, GroupChat } from '../../api/types';
 import { VerticalResizeHandle } from './VerticalResizeHandle';
 import { CreateGroupDialog } from '../agents/CreateGroupDialog';
 import { AddAgentDialog } from '../agents/AddAgentDialog';
+import { AgentDetailDialog } from '../agents/AgentDetailDialog';
 
 interface LeftSidebarProps {
   onCreateSession: (agentId: string) => void;
@@ -28,6 +30,7 @@ interface LeftSidebarProps {
     personality: string;
     province: string;
   }) => Promise<void>;
+  onFetchAgentDetail: (agentId: string) => Promise<AgentDetail>;
 }
 
 export function LeftSidebar({
@@ -36,6 +39,7 @@ export function LeftSidebar({
   onSelectGroup,
   onCreateGroup,
   onAddAgent,
+  onFetchAgentDetail,
 }: LeftSidebarProps) {
   const agentSessions = useAgentStore((s) => s.agentSessions);
   const currentAgentId = useAgentStore((s) => s.currentAgentId);
@@ -51,6 +55,7 @@ export function LeftSidebar({
   const [showAgentMenu, setShowAgentMenu] = useState(false);
   const [showAddAgentDialog, setShowAddAgentDialog] = useState(false);
   const [showCreateGroupDialog, setShowCreateGroupDialog] = useState(false);
+  const [agentDetailTarget, setAgentDetailTarget] = useState<{ agentId: string; agentName: string } | null>(null);
 
   // Outside-click to close agent menu
   const menuRef = useRef<HTMLDivElement>(null);
@@ -139,16 +144,27 @@ export function LeftSidebar({
                         {group.sessions.length}
                       </span>
                     </button>
-                    <button
-                      type="button"
-                      onClick={() => onCreateSession(group.agent_id)}
-                      disabled={creatingAgentId === group.agent_id}
-                      className="rounded-md p-0.5 disabled:opacity-60 hover:opacity-80"
-                      style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
-                      title={`为 ${group.agent_name} 新建会话`}
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                    </button>
+                    <div className="flex items-center gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => setAgentDetailTarget({ agentId: group.agent_id, agentName: group.agent_name })}
+                        className="rounded-md p-0.5 hover:opacity-80"
+                        style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
+                        title={`查看 ${group.agent_name} 详情`}
+                      >
+                        <Info className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onCreateSession(group.agent_id)}
+                        disabled={creatingAgentId === group.agent_id}
+                        className="rounded-md p-0.5 disabled:opacity-60 hover:opacity-80"
+                        style={{ borderWidth: 1, borderColor: 'var(--color-border)', borderStyle: 'solid', backgroundColor: 'var(--color-surface)' }}
+                        title={`为 ${group.agent_name} 新建会话`}
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
                   </div>
 
                   {expandedAgents[group.agent_id] && (
@@ -285,6 +301,15 @@ export function LeftSidebar({
         <AddAgentDialog
           onClose={() => setShowAddAgentDialog(false)}
           onAddAgent={onAddAgent}
+        />
+      )}
+
+      {agentDetailTarget && (
+        <AgentDetailDialog
+          agentId={agentDetailTarget.agentId}
+          agentName={agentDetailTarget.agentName}
+          fetchDetail={onFetchAgentDetail}
+          onClose={() => setAgentDetailTarget(null)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- Add `GET /api/agents/{agent_id}` endpoint returning soul.md content and data_scope.yaml config
- New `AgentDetailDialog` component with tabbed Soul / Data Scope view
- Info button on each agent in left sidebar opens the dialog
- Completes task #41 requirement: "点击agent可以弹窗显示其Soul的内容和data scope的权限设置"

## Changes
- `packages/server/simu_server/routes/client.py` — new agent detail endpoint
- `web/src/components/agents/AgentDetailDialog.tsx` — new dialog component
- `web/src/components/layout/LeftSidebar.tsx` — info button + dialog wiring
- `web/src/api/types.ts` — `AgentDetail` interface
- `web/src/api/client.ts` — `getAgentDetail()` method
- `web/src/App.tsx` — pass fetch callback prop

## Test plan
- [ ] Click info button next to agent name in sidebar — dialog opens
- [ ] Soul tab renders markdown content from soul.md
- [ ] Data Scope tab renders structured data_scope.yaml fields
- [ ] Dialog closes on backdrop click or X button
- [ ] Dark mode styling correct
- [ ] Agent without soul.md/data_scope.yaml shows placeholder text

🤖 Generated with [Claude Code](https://claude.com/claude-code)