### PR TITLE
fix: catch CancelledError in MCP reconnect and tool execution

### DIFF
--- a/packages/sdk/simu_sdk/mcp_client.py
+++ b/packages/sdk/simu_sdk/mcp_client.py
@@ -85,7 +85,7 @@ class _MCPSession:
             if not self.connected:
                 try:
                     await self.open()
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     if attempt == _MAX_RECONNECT_ATTEMPTS - 1:
                         raise
                     logger.warning("MCP reconnect attempt %d failed for %s", attempt + 1, self._url)

--- a/packages/sdk/simu_sdk/react.py
+++ b/packages/sdk/simu_sdk/react.py
@@ -10,6 +10,7 @@ Iteration and tool-call limits prevent runaway loops.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import TYPE_CHECKING, Any
@@ -316,6 +317,9 @@ class ReActLoop:
             if isinstance(output, ToolResult):
                 return output
             return ToolResult(output=str(output))
+        except asyncio.CancelledError:
+            logger.error("Tool %s cancelled by async runtime", tc.name)
+            return ToolResult(output=f"Tool error: {tc.name} was cancelled", success=False)
         except Exception as exc:
             logger.exception("Tool %s failed", tc.name)
             return ToolResult(output=f"Tool error: {exc}", success=False)

--- a/packages/sdk/simu_sdk/tools/mcp_adapter.py
+++ b/packages/sdk/simu_sdk/tools/mcp_adapter.py
@@ -110,8 +110,15 @@ class MCPToolAdapter:
     def _to_tool_meta(tool: Any) -> ToolMeta:
         """Convert an MCP ``Tool`` object to a ``ToolMeta``."""
         schema = tool.inputSchema or {}
+        defs = schema.get("$defs", schema.get("definitions", {}))
         properties = dict(schema.get("properties", {}))
         required = list(schema.get("required", []))
+
+        # Resolve $ref pointers so the schema is self-contained
+        if defs:
+            properties = {
+                k: _resolve_refs(v, defs) for k, v in properties.items()
+            }
 
         # Remove auto-injected parameters from LLM-visible schema
         injected = _INJECTED_PARAMS.get(tool.name, set())
@@ -299,6 +306,22 @@ class MCPToolAdapter:
             output=f"Task {action}. Returning to parent session {parent_id}.",
             ends_loop=True,
         )
+
+
+def _resolve_refs(node: Any, defs: dict[str, Any]) -> Any:
+    """Recursively replace ``$ref`` pointers with the referenced definition."""
+    if isinstance(node, dict):
+        if "$ref" in node and len(node) == 1:
+            # e.g. {"$ref": "#/$defs/EffectParam"}
+            ref_path = node["$ref"]
+            ref_name = ref_path.rsplit("/", 1)[-1]
+            if ref_name in defs:
+                return _resolve_refs(defs[ref_name], defs)
+            return node  # unresolvable ref — keep as-is
+        return {k: _resolve_refs(v, defs) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_resolve_refs(item, defs) for item in node]
+    return node
 
 
 def _extract_text(result: Any) -> str:


### PR DESCRIPTION
## Summary
- **Root cause**: `CancelledError` (a `BaseException` in Python 3.9+) was escaping `except Exception` handlers in the MCP client reconnect path and ReAct tool execution, killing the entire event processing pipeline
- **Symptom**: `create_task_session` tool calls recorded in tape but never completed — no `tool_result` event, agent response never delivered
- **Additional fix**: MCP tool schemas with Pydantic-generated `$defs`/`$ref` were not being resolved, leaving broken references in LLM function definitions

## Changes
1. `mcp_client.py`: `except Exception` → `except (Exception, asyncio.CancelledError)` in reconnect path
2. `react.py`: Added `except asyncio.CancelledError` handler in `_execute_tool()` to return error ToolResult instead of propagating
3. `mcp_adapter.py`: Added `_resolve_refs()` to recursively inline `$ref` pointers from Pydantic-generated schemas

## Test plan
- [ ] Start backend, send "你是谁" to an agent — verify response is visible
- [ ] Send "代我问问张廷玉身体如何" — verify task session is created and completes
- [ ] Trigger MCP connection timeout (e.g. restart server mid-call) — verify agent recovers gracefully instead of dying

🤖 Generated with [Claude Code](https://claude.com/claude-code)