### PR TITLE
fix: catch CancelledError in MCP close, save_state, and report_error

### DIFF
--- a/packages/sdk/simu_sdk/framework/plugins/mcp_plugin.py
+++ b/packages/sdk/simu_sdk/framework/plugins/mcp_plugin.py
@@ -68,16 +68,22 @@ class MCPClientPlugin:
             and not session_id.startswith("task:")
             and ended_by_tool is None
         ):
-            await self._mcp.post_message(
-                recipients=["player"],
-                message=model_output,
-                session_id=session_id,
-            )
+            try:
+                await self._mcp.post_message(
+                    recipients=["player"],
+                    message=model_output,
+                    session_id=session_id,
+                )
+            except (Exception, asyncio.CancelledError):
+                logger.warning("Failed to post message for session %s", session_id)
 
         # Complete invocation
         invocation_id = getattr(event, "invocation_id", None)
         if invocation_id:
-            await self._mcp.complete_invocation(invocation_id)
+            try:
+                await self._mcp.complete_invocation(invocation_id)
+            except (Exception, asyncio.CancelledError):
+                logger.warning("Failed to complete invocation %s", invocation_id)
 
     async def _update_summary(self, session_id: str) -> None:
         try:

--- a/packages/sdk/simu_sdk/mcp_client.py
+++ b/packages/sdk/simu_sdk/mcp_client.py
@@ -74,7 +74,7 @@ class _MCPSession:
         for cm in reversed(self._contexts):
             try:
                 await cm.__aexit__(None, None, None)
-            except Exception:
+            except BaseException:
                 pass
         self._contexts.clear()
         self._session = None
@@ -297,11 +297,14 @@ class MCPServerClient:
         """Report an unhandled error back to the Server."""
         logger.exception("Error processing event %s", event.event_id)
         if event.invocation_id:
-            await self.complete_invocation(
-                event.invocation_id,
-                status="failed",
-                error=str(error),
-            )
+            try:
+                await self.complete_invocation(
+                    event.invocation_id,
+                    status="failed",
+                    error=str(error),
+                )
+            except (Exception, asyncio.CancelledError):
+                logger.warning("Failed to report error for %s", event.event_id)
 
     # ------------------------------------------------------------------
     # Role queries (role-mcp)


### PR DESCRIPTION
## Summary
PR #94 修复了 `call_tool` reconnect 和 `_execute_tool` 中的 CancelledError 逃逸，但还有三个逃逸路径导致任务创建失败：

1. **`_MCPSession.close()`** — `except Exception: pass` 不捕获 CancelledError，导致 `call_tool` 在捕获 CancelledError 后调用 `self.close()` 时再次抛出 CancelledError
2. **`mcp_plugin.py save_state`** — `post_message` 和 `complete_invocation` 无 try/except，CancelledError 穿透 bub 框架 hook 管线
3. **`report_error`** — 错误报告时 `complete_invocation` 抛出 CancelledError 导致级联失败

## Changes
- `mcp_client.py`: `close()` 中 `except Exception` → `except BaseException`
- `mcp_client.py`: `report_error()` 包裹 `complete_invocation` 调用
- `mcp_plugin.py`: `save_state()` 中 `post_message` 和 `complete_invocation` 各加 try/except

## Test plan
- [ ] 重启 backend，发送消息给 agent，验证响应正常返回
- [ ] 触发 MCP 连接超时，验证 agent 不崩溃且能恢复
- [ ] 检查日志中不再出现 "Event processing cancelled" 级联错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)