### PR TITLE
fix: remove automatic memory retrieval, use agentic RAG only

### DIFF
--- a/packages/sdk/simu_sdk/framework/agent.py
+++ b/packages/sdk/simu_sdk/framework/agent.py
@@ -313,8 +313,6 @@ class SimuAgent:
         from simu_sdk.framework.plugins.context_plugin import SimuContextPlugin
         from simu_sdk.framework.plugins.react_plugin import SimuReActPlugin
         from simu_sdk.framework.plugins.mcp_plugin import MCPClientPlugin
-        from simu_sdk.framework.plugins.memory_plugin import SimuMemoryPlugin
-
         pm = self._framework._plugin_manager
         pm.register(SimuTapePlugin(self.tape), name="SimuTapePlugin")
         pm.register(SimuContextPlugin(
@@ -323,7 +321,6 @@ class SimuAgent:
             data_scope=self.data_scope,
             session_state=self.session_state,
         ), name="SimuContextPlugin")
-        pm.register(SimuMemoryPlugin(self.memory_retriever), name="SimuMemoryPlugin")
         pm.register(SimuReActPlugin(
             llm=self.llm,
             tools=self.tools,


### PR DESCRIPTION
## Summary
- Remove `SimuMemoryPlugin` from pipeline registration — it ran ChromaDB vector search (3 sequential queries) on **every** pipeline invocation, causing 2-3 minute delays
- Memory retrieval is now purely agentic: agent calls `retrieve_memory` tool when needed
- `MemoryTools.retrieve_memory` (already registered) provides the same search capability on demand

## Root cause
`SimuMemoryPlugin.load_state` executed `retriever.search()` automatically on every event, triggering keyword search + session vector search + view vector search through ChromaDB. This was the primary bottleneck in the 3-minute task session startup delay.

## Test plan
- [ ] Verify agent starts without errors (no import/registration failures)
- [ ] Verify `retrieve_memory` tool is still available in agent tool list
- [ ] Verify task session creation is significantly faster (no ChromaDB overhead)
- [ ] Verify agent can still recall memories when explicitly using `retrieve_memory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)